### PR TITLE
Update Technische Universität München with correct domain name

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -3439,7 +3439,7 @@
  {"web_page": "http://www.tu-dresden.de/", "country": "Germany", "domain": "tu-dresden.de", "name": "Technische Universit\u00e4t Dresden"},
  {"web_page": "http://www.tu-harburg.de/", "country": "Germany", "domain": "tu-harburg.de", "name": "Technische Universit\u00e4t Hamburg-Harburg"},
  {"web_page": "http://www.tu-ilmenau.de/", "country": "Germany", "domain": "tu-ilmenau.de", "name": "Technische Universit\u00e4t Ilmenau"},
- {"web_page": "http://www.tu-muenchen.de/", "country": "Germany", "domain": "tu-muenchen.de", "name": "Technische Universit\u00e4t M\u00fcnchen"},
+ {"web_page": "http://www.tum.de/", "country": "Germany", "domain": "tum.de", "name": "Technische Universit\u00e4t M\u00fcnchen"},
  {"web_page": "http://www.paderborn.de/theofak/", "country": "Germany", "domain": "paderborn.de", "name": "Theologische Fakult\u00e4t Paderborn"},
  {"web_page": "http://www.uni-trier.de/uni/theo/", "country": "Germany", "domain": "uni-trier.de", "name": "Theologische Fakult\u00e4t Trier"},
  {"web_page": "http://www.thh-friedensau.de/", "country": "Germany", "domain": "thh-friedensau.de", "name": "Theologische Hochschule Friedensau"},


### PR DESCRIPTION
The old handle "tu-muenchen.de" is still working, but the new domain name "tum.de" is used for university email adresses and is the newer one. Thus we should switch to "tum.de"