### PR TITLE
Adding further domain for Ludwig-Maximilians-Universität München

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -3549,6 +3549,7 @@
  {"web_page": "http://www.uni-mannheim.de/", "country": "Germany", "domain": "uni-mannheim.de", "name": "Universit\u00e4t Mannheim"},
  {"web_page": "http://www.uni-marburg.de/", "country": "Germany", "domain": "uni-marburg.de", "name": "Phillips-Universit\u00e4t Marburg"},
  {"web_page": "http://www.uni-muenchen.de/", "country": "Germany", "domain": "uni-muenchen.de", "name": "Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen"},
+ {"web_page": "http://www.lmu.de/", "country": "Germany", "domain": "lmu.de", "name": "Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen"},
  {"web_page": "http://www.uni-muenster.de/", "country": "Germany", "domain": "uni-muenster.de", "name": "Westf\u00e4lische Wilhelms-Universit\u00e4t M\u00fcnster"},
  {"web_page": "http://www.uni-oldenburg.de/", "country": "Germany", "domain": "uni-oldenburg.de", "name": "Carl von Ossietzky Universit\u00e4t Oldenburg"},
  {"web_page": "http://www.uni-osnabrueck.de/", "country": "Germany", "domain": "uni-osnabrueck.de", "name": "Universit\u00e4t Osnabr\u00fcck"},


### PR DESCRIPTION
Generally, all students’ email addresses use the lmu.de domain e.g.
sven.svenson@campus.lmu.de