### PR TITLE
domain of Fachhochschule Deggendorf has changed

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -3329,7 +3329,7 @@
  {"web_page": "http://www.fh-bochum.de/", "country": "Germany", "domain": "fh-bochum.de", "name": "Fachhochschule Bochum"},
  {"web_page": "http://www.fh-bonn-rhein-sieg.de/", "country": "Germany", "domain": "fh-bonn-rhein-sieg.de", "name": "Fachhochschule Bonn-Rhein-Sieg"},
  {"web_page": "http://www.fh-brandenburg.de/", "country": "Germany", "domain": "fh-brandenburg.de", "name": "Fachhochschule Brandenburg"},
- {"web_page": "http://www.fh-deggendorf.de/", "country": "Germany", "domain": "fh-deggendorf.de", "name": "Fachhochschule Deggendorf"},
+ {"web_page": "http://www.th-deg.de/", "country": "Germany", "domain": "th-deg.de", "name": "Technische Hochschule Deggendorf"},
  {"web_page": "http://www.fh-dortmund.de/", "country": "Germany", "domain": "fh-dortmund.de", "name": "Fachhochschule Dortmund"},
  {"web_page": "http://www.fh-duesseldorf.de/", "country": "Germany", "domain": "fh-duesseldorf.de", "name": "Fachhochschule D\u00fcsseldorf"},
  {"web_page": "http://www.fhdw.bib.de/", "country": "Germany", "domain": "fhdw.bib.de", "name": "Fachhochschule f\u00fcr die Wirtschaft"},


### PR DESCRIPTION
They renamed from Fachhochschule Deggendorf to Technische Hochschule
Deggendorf couple of years ago.