### PR TITLE
Differing e-mail/http domain names

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -32454,7 +32454,7 @@
   {
       "alpha_two_code": "IT",
       "country": "Italy",
-      "domain": "uniroma2.it",
+      "domain": "uniroma2.eu",
       "name": "University of Roma &quot;Tor Vergata&quot;",
       "web_page": "http://www.uniroma2.it/"
   },


### PR DESCRIPTION
I just had a user of our project website try to use his student e-mail address to download something, which didn't work, because apparently his university (University of Roma "Tor Vergata", http://uniroma2.it/) uses a different domain for student e-mail accounts than they do for the website: `first.last@students.uniroma2.eu`. It looks half dodgy at first glance because that URL serves only a placeholder CMS website, but I did find a reference from uniroma2.it that uses the .eu domain [here](https://translate.google.nl/translate?hl=en&sl=it&u=http://docs.ccd.uniroma2.it/pmwiki.php/Main/Office365&prev=search), so I guess it's legit. I also don't see why someone would try to spoof an e-mail address like this to download our project, I believe it's the first download in a year or something and it's supposed to be completely open-source anyway...