### PR TITLE
Issue #35 - typo in `Mehmet Akif Ersoy University` name

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -58707,7 +58707,7 @@
       "alpha_two_code": "TR",
       "country": "Turkey",
       "domain": "mehmetakif.edu.tr",
-      "name": "Mehemet Akif Ersoy University",
+      "name": "Mehmet Akif Ersoy University",
       "web_page": "http://www.mehmetakif.edu.tr/"
   },
   {


### PR DESCRIPTION
#35 
correct a typo in a university name .