### PR TITLE
Edit Universitas Telkom data

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -29045,9 +29045,9 @@
   {
       "alpha_two_code": "ID",
       "country": "Indonesia",
-      "domain": "stttelkom.ac.id",
-      "name": "Institut Teknologi Telkom",
-      "web_page": "http://www.stttelkom.ac.id/"
+      "domain": "telkomuniversity.ac.id",
+      "name": "Universitas Telkom",
+      "web_page": "http://www.telkomuniversity.ac.id/"
   },
   {
       "alpha_two_code": "ID",


### PR DESCRIPTION
"Institut Teknologi Telkom" is an old name for new "Universitas Telkom"
http://www.stttelkom.ac.id is no longer available since it moving to http://www.telkomuniversity.ac.id