### PR TITLE
Correcting University of Sydney to their published domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -9550,9 +9550,9 @@
   {
       "alpha_two_code": "AU",
       "country": "Australia",
-      "domain": "usyd.edu.au",
+      "domain": "sydney.edu.au",
       "name": "University of Sydney",
-      "web_page": "http://www.usyd.edu.au/"
+      "web_page": "http://sydney.edu.au/"
   },
   {
       "alpha_two_code": "AU",


### PR DESCRIPTION
The former domain of usyd.edu.au is valid but is not the domain that is actively being used by members of the university, most notably in their emails. Contact all comes from sydney.edu.au. Until multiple domains per institution is possible I think sydney.edu.au is more correct for University of Sydney.