### PR TITLE
Fix Slovak Medical University entry domain and web_page

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -51118,7 +51118,7 @@
   {
       "alpha_two_code": "SK",
       "country": "Slovakia",
-      "domain": "",
+      "domain": "szu.sk",
       "name": "Slovak Medical University",
       "web_page": "http:///www.szu.sk/"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -51120,7 +51120,7 @@
       "country": "Slovakia",
       "domain": "szu.sk",
       "name": "Slovak Medical University",
-      "web_page": "http:///www.szu.sk/"
+      "web_page": "http://www.szu.sk/"
   },
   {
       "alpha_two_code": "SK",


### PR DESCRIPTION
The original entry contains empty **domain** member and excessive slashes in the **web_page** member
The fixed entry contains the correct **domain** member [szu.sk](http://www.szu.sk/) and correct **web_page** member [http://www.szu.sk/](http://www.szu.sk/) 