### PR TITLE
pw.edu.pl name update

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -46555,7 +46555,7 @@
       "alpha_two_code": "PL",
       "country": "Poland",
       "domain": "pw.edu.pl",
-      "name": "Technical University of Warsaw",
+      "name": "Warsaw University of Technology",
       "web_page": "http://www.pw.edu.pl/"
   },
   {


### PR DESCRIPTION
According to official website https://www.pw.edu.pl/engpw proper name in english is "Warsaw University of Technology"