### PR TITLE
Added the second domain of the University of Aberdeen.

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -57179,6 +57179,13 @@
     {
         "alpha_two_code": "GB",
         "country": "United Kingdom",
+        "domain": "aberdeen.ac.uk",
+        "name": "University of Aberdeen",
+        "web_page": "http://www.abdn.ac.uk/"
+    },
+    {
+        "alpha_two_code": "GB",
+        "country": "United Kingdom",
         "domain": "aber.ac.uk",
         "name": "University of Wales, Aberystwyth",
         "web_page": "http://www.aber.ac.uk/"


### PR DESCRIPTION
The University of Aberdeen has two domain names - one for staff and services and one for students. The one for students was missing from your list.