### PR TITLE
added second domain for ulster university uk

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -58257,6 +58257,13 @@
     {
         "alpha_two_code": "GB",
         "country": "United Kingdom",
+        "domain": "ulster.ac.uk",
+        "name": "University of Ulster",
+        "web_page": "https://www.ulster.ac.uk/"
+    },
+    {
+        "alpha_two_code": "GB",
+        "country": "United Kingdom",
         "domain": "umds.ac.uk",
         "name": "United Medical and Dental Schools, University of London",
         "web_page": "http://www.umds.ac.uk/"


### PR DESCRIPTION
Adding a second domain name for the University of Ulster. 