### PR TITLE
Walla Walla College was renamed Walla Walla University and its domain has changed

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -14075,13 +14075,13 @@
   },
   {
     "web_pages": [
-      "http://www.wwc.edu/"
+      "http://www.wallawalla.edu/"
     ],
-    "name": "Walla Walla College",
+    "name": "Walla Walla University",
     "alpha_two_code": "US",
-    "state-province": null,
+    "state-province": "Washington",
     "domains": [
-      "wwc.edu"
+      "wallawalla.edu"
     ],
     "country": "United States"
   },


### PR DESCRIPTION
http://gleanernow.com/news/2006/11/walla-walla-college-change-name