### PR TITLE
Remove Calmar suffix from Northeast Iowa Community College

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -108763,7 +108763,7 @@
     "web_pages": [
       "http://www.nicc.edu"
     ],
-    "name": "Northeast Iowa Community College-​Calmar",
+    "name": "Northeast Iowa Community College",
     "alpha_two_code": "US",
     "state-province": null,
     "domains": [


### PR DESCRIPTION
Calmar is only one of NICC's two campuses. I propose removing the `-Calmar` suffix from the NICC entry.