### PR TITLE
Add university of muenster short url

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -44250,7 +44250,8 @@
   },
   {
     "web_pages": [
-      "http://www.uni-muenster.de/"
+      "http://www.uni-muenster.de/",
+      "http://www.wwu.de/"
     ],
     "name": "Westfälische Wilhelms-Universität Münster",
     "alpha_two_code": "DE",

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -44256,7 +44256,8 @@
     "alpha_two_code": "DE",
     "state-province": null,
     "domains": [
-      "uni-muenster.de"
+      "uni-muenster.de",
+      "wwu.de"
     ],
     "country": "Germany"
   },


### PR DESCRIPTION
This short url is also used for students email adresses.