### PR TITLE
University of Manchester canonical domain is manchester.ac.uk, plus mbs.ac.uk

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -101213,12 +101213,14 @@
   },
   {
     "web_pages": [
-      "http://www.man.ac.uk/"
+      "http://www.manchester.ac.uk/"
     ],
     "name": "University of Manchester",
     "alpha_two_code": "GB",
     "state-province": null,
     "domains": [
+      "manchester.ac.uk",
+      "mbs.ac.uk",
       "man.ac.uk"
     ],
     "country": "United Kingdom"


### PR DESCRIPTION
Manchester Business School is part of the University of Manchester but uses its own domain for web and email.

University of Manchester deprecated man.ac.uk a long time ago, now uses manchester.ac.uk