### PR TITLE
Uni Karlsruhe -> Karlsruhe Institute of Technology (KIT)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -41688,7 +41688,7 @@
     "state-province": null,
     "domains": [
       "hochschule-bonn-rhein-sieg.de",
-	  "h-brs.de"
+      "h-brs.de"
     ],
     "country": "Germany"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -44191,13 +44191,13 @@
   },
   {
     "web_pages": [
-      "http://www.uni-karlsruhe.de/"
+      "http://www.kit.edu/"
     ],
-    "name": "Universität Fridericana Karlsruhe (Technische Hochschule)",
+    "name": "Karlsruher Institut für Technologie",
     "alpha_two_code": "DE",
     "state-province": null,
     "domains": [
-      "uni-karlsruhe.de"
+      "kit.edu"
     ],
     "country": "Germany"
   },


### PR DESCRIPTION
[...] the foundation of Forschungszentrum Karlsruhe and [...] the foundation of Universität Karlsruhe [...]  merge into the new legal entity of KIT [...] on October 01, 2009.
Source: [http://www.kit.edu/kit/english/history.php](http://www.kit.edu/kit/english/history.php)