### PR TITLE
Added Lambton College, Hochschule Hannover.

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -116171,5 +116171,18 @@
       "dhbw-mannheim.de"
     ],
     "country": "Germany"
+  },
+  {
+    "web_pages": [
+      "https://www.hs-hannover.de/"
+    ],
+    "name": "Hochschule Hannover",
+    "alpha_two_code": "DE",
+    "state-province": "null",
+    "domains": [
+      "hs-hannover.de",
+      "stud.hs-hannover.de"
+    ],
+    "country": "Germany"
   }
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -6552,6 +6552,19 @@
   },
   {
     "web_pages": [
+      "https://www.lambtoncollege.ca"
+    ],
+    "name": "Lambton College",
+    "alpha_two_code": "CA",
+    "state-province": "Sarnia",
+    "domains": [
+      "lambtoncollege.ca",
+      "mylambton.ca"
+    ],
+    "country": "Canada"
+  },
+  {
+    "web_pages": [
       "http://www.langston.edu/"
     ],
     "name": "Langston University",


### PR DESCRIPTION
Newly added institutions:

- Lambton College (CA)
- Hochschule Hannover (DE)

Note: Originally added institutions in alphabetical order, hence the disparity on the location of additions in the commits.