### PR TITLE
Added current domain used by Hogeschool Rotterdam

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -75607,7 +75607,8 @@
     "alpha_two_code": "NL",
     "state-province": null,
     "domains": [
-      "hro.nl"
+      "hro.nl",
+      "hr.nl"
     ],
     "country": "Netherlands"
   },


### PR DESCRIPTION
While the hro.nl domain still works, email addresses for new students are in the format of hr.nl.