### PR TITLE
Added Business and Technology University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -116247,5 +116247,18 @@
       "mmibordeaux.com"
     ],
     "country": "France"
+  },
+  {
+    "web_pages": [
+      "http://btu.ge"
+    ],
+    "name": "Business and Technology University",
+    "alpha_two_code": "GE",
+    "state-province": null,
+    "domains": [
+      "btu.ge",
+      "btu.edu.ge"
+    ],
+    "country": "Georgia"
   }
 ]


### PR DESCRIPTION
I messed up on my last pull request because I deleted my fork and couldn't find a way to update it...sorry for the inconvenience.

I fixed what you told me to (adding `btu.ge` to domains list).

[Here](https://btu.ge/en/about-us/authorization--accreditation "Official notice.") is the accreditation information again, just in case.