### PR TITLE
Update: added domains + webpage for École des Mines d'Alès (FR)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -38682,13 +38682,15 @@
   },
   {
     "web_pages": [
-      "http://www.ensm-ales.fr/"
+      "https://www.mines-ales.fr/"
     ],
     "name": "Ecole Nationale Supérieure des Mines d'Alès",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": [
-      "ensm-ales.fr"
+      "ensm-ales.fr",
+      "mines-ales.fr",
+      "mines-ales.org"
     ],
     "country": "France"
   },


### PR DESCRIPTION
Domain `mines-ales.org` is used for students' addresses (source: https://www.mines-ales.fr/reseau/e-mail-eleves/index.html).