### PR TITLE
Fix name and domain of TU Dortmund

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -43958,13 +43958,13 @@
   },
   {
     "web_pages": [
-      "http://www.uni-dortmund.de/"
+      "http://www.tu-dortmund.de/"
     ],
-    "name": "Universität Dortmund",
+    "name": "Technische Universität Dortmund",
     "alpha_two_code": "DE",
     "state-province": null,
     "domains": [
-      "uni-dortmund.de"
+      "tu-dortmund.de"
     ],
     "country": "Germany"
   },


### PR DESCRIPTION
The name and the domain of the university of Dortmund were outdated.