### PR TITLE
Remove duplicate Ohio U entry with old domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -8512,18 +8512,6 @@
   },
   {
     "web_pages": [
-      "http://www.ohiou.edu/"
-    ],
-    "name": "Ohio University",
-    "alpha_two_code": "US",
-    "state-province": null,
-    "domains": [
-      "ohiou.edu"
-    ],
-    "country": "United States"
-  },
-  {
-    "web_pages": [
       "http://www.owu.edu/"
     ],
     "name": "Ohio Wesleyan University",


### PR DESCRIPTION
ohiou.edu domain has been decommissioned and now redirects to ohio.edu. Remove outdated duplicate entry

https://www.ohio.edu/oit/web/websites/custom-web-addresses/decommissioned