### PR TITLE
Fix Mount Royal University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -25577,13 +25577,13 @@
   },
   {
     "web_pages": [
-      "http://www.mtroyal.ab.ca/"
+      "http://www.mtroyal.ca/"
     ],
-    "name": "Mount Royal College",
+    "name": "Mount Royal University",
     "alpha_two_code": "CA",
     "state-province": null,
     "domains": [
-      "mtroyal.ab.ca"
+      "mtroyal.ca"
     ],
     "country": "Canada"
   },


### PR DESCRIPTION
This fixes MRU's website, name, and domain. I'm unsure if I should have kept the old domain, but all MRU emails now end in @mtroyal.ca instead of @mtroyal.ab.ca.