### PR TITLE
University of Aberdeen

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -100410,7 +100410,8 @@
     "alpha_two_code": "GB",
     "state-province": null,
     "domains": [
-      "abdn.ac.uk"
+      "abdn.ac.uk",
+      "aberdeen.ac.uk"
     ],
     "country": "United Kingdom"
   },


### PR DESCRIPTION
Added Aberdeen University student email domain name. The original one is staff-only