### PR TITLE
Update HTW domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -42582,13 +42582,14 @@
   },
   {
     "web_pages": [
-      "http://www.fhtw-berlin.de/"
+      "https://www.htw-berlin.de/"
     ],
-    "name": "Fachhochschule für Technik und Wirtschaft Berlin",
+    "name": "Hochschule für Technik und Wirtschaft Berlin",
     "alpha_two_code": "DE",
     "state-province": null,
     "domains": [
-      "fhtw-berlin.de"
+      "fhtw-berlin.de",
+      "htw-berlin.de"
     ],
     "country": "Germany"
   },


### PR DESCRIPTION
"Fachhochschule für Technik und Wirtschaft Berlin" has gone through a rebranding to "Hochschule für Technik und Wirtschaft Berlin" a few years ago. Due to this, the domain changed to "htw-berlin.de". The old domain still receives emails so I kept it in the list.