### PR TITLE
update for the Lomonosov Moscow State Univeristy and IBCH RAS

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -87700,9 +87700,9 @@
   },
   {
     "web_pages": [
-      "http://www.msu.ru/"
+      "https://www.msu.ru/"
     ],
-    "name": "Moscow State University",
+    "name": "Lomonosov Moscow State University",
     "alpha_two_code": "RU",
     "state-province": null,
     "domains": [

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -86680,6 +86680,18 @@
   },
   {
     "web_pages": [
+      "http://www.ibch.ru/"
+    ],
+    "name": "Shemyakin–Ovchinnikov Institute of bioorganic chemistry RAS",
+    "alpha_two_code": "RU",
+    "state-province": null,
+    "domains": [
+      "ibch.ru"
+    ],
+     "country": "Russian Federation"
+  },
+  {
+    "web_pages": [
       "http://www.ibi.spb.ru/"
     ],
     "name": "International Banking Institute, St. Petersburg",


### PR DESCRIPTION
The official name of the university is the Lomonosov Moscow State University (https://msu.ru/en). Also several years ago the main site switched to https protocol.