### PR TITLE
Replace USTU with URFU

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -89368,13 +89368,13 @@
   },
   {
     "web_pages": [
-      "http://www.ustu.ru/"
+      "https://urfu.ru"
     ],
-    "name": "Ural State Technical University",
+    "name": "Ural Federal University",
     "alpha_two_code": "RU",
     "state-province": null,
     "domains": [
-      "ustu.ru"
+      "urfu.ru"
     ],
     "country": "Russian Federation"
   },


### PR DESCRIPTION
Ural State Technical University was renamed to Ural Federal University in 2010: https://urfu.ru/en/about-the-university/history/2000-10/