### PR TITLE
added WU domain to Vienna Univ of Econ and Business

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -18384,7 +18384,8 @@
     "alpha_two_code": "AT",
     "state-province": null,
     "domains": [
-      "wu-wien.ac.at"
+      "wu-wien.ac.at",
+      "wu.ac.at"
     ],
     "country": "Austria"
   },


### PR DESCRIPTION
Wirtschaftsuniversität Wien (Vienna Univ. of Econ. and Business) has the domain wu.ac.at. See: https://www.wu.ac.at/en/