### PR TITLE
changed web_pages and domains for Islamic Azad University, Qazvin

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -54885,13 +54885,13 @@
   },
   {
     "web_pages": [
-      "http://www.qazviniau.ac.ir/"
+      "http://qiau.ac.ir/"
     ],
     "name": "Islamic Azad University, Qazvin",
     "alpha_two_code": "IR",
     "state-province": null,
     "domains": [
-      "qazviniau.ac.ir"
+      "qiau.ac.ir"
     ],
     "country": "Iran"
   },


### PR DESCRIPTION
The domain for Islamic Azad University, Qazvin was wrong.
Corrected.