### PR TITLE
Added Nanjing University of Information Science and Technology, Nanjing, China.

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -116374,5 +116374,17 @@
     "domains": [
       "utfpr.edu.br"
     ]
+  },
+  {
+    "web_pages": [
+      "https://www.nuist.edu.cn/"
+    ],
+    "name": "Nanjing University of Information Science and Technology",
+    "alpha_two_code": "CN",
+    "state-province": null,
+    "domains": [
+      "nuist.edu.cn"
+    ],
+    "country": "China"
   }
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -116381,7 +116381,7 @@
     ],
     "name": "Nanjing University of Information Science and Technology",
     "alpha_two_code": "CN",
-    "state-province": null,
+    "state-province": "Jiangsu",
     "domains": [
       "nuist.edu.cn"
     ],


### PR DESCRIPTION
Nanjing University of Information Science and Technology
Originally called Nanjing Institute of Meteorology (until 2004)