### PR TITLE
Imperial college now uses imperial.ac.uk instead of ic.ac.uk

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -100940,12 +100940,13 @@
   },
   {
     "web_pages": [
-      "http://www.ic.ac.uk/"
+      "http://www.imperial.ac.uk/"
     ],
     "name": "Imperial College London",
     "alpha_two_code": "GB",
     "state-province": null,
     "domains": [
+      "imperial.ac.uk",
       "ic.ac.uk"
     ],
     "country": "United Kingdom"


### PR DESCRIPTION
Update info of imperial college