### PR TITLE
Updated the domains of the University of Huelva

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -92324,7 +92324,15 @@
     "alpha_two_code": "ES",
     "state-province": null,
     "domains": [
-      "uhu.es"
+      "uhu.es",
+      "alu.uhu.es",
+      "dti.uhu.es",
+      "dci.uhu.es",
+      "sacu.uhu.es",
+      "caruh.uhu.es",
+      "dcqm.uhu.es",
+      "inv.uhu.es",
+      "sc.uhu.es"
     ],
     "country": "Spain"
   },


### PR DESCRIPTION
The University of Huelva uses different subdomains for mailboxes, would it be right to change it like this?