### PR TITLE
Fix domain and website for uc.cl

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -26658,13 +26658,13 @@
   },
   {
     "web_pages": [
-      "http://www.puc.cl/"
+      "https://www.uc.cl/"
     ],
     "name": "Pontificia Universidad Catolica de Chile",
     "alpha_two_code": "CL",
     "state-province": null,
     "domains": [
-      "puc.cl"
+      "uc.cl"
     ],
     "country": "Chile"
   },


### PR DESCRIPTION
Not sure the domain changed or always was `uc.cl`, but `puc.cl` isn't correct.