### PR TITLE
Student emails use g subdomain for nsu.ru

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -87692,7 +87692,8 @@
     "alpha_two_code": "RU",
     "state-province": null,
     "domains": [
-      "nsu.ru"
+      "nsu.ru",
+      "g.nsu.ru"
     ],
     "country": "Russian Federation"
   },


### PR DESCRIPTION
According to student, the `g.` subdomain is used for active student emails.