### PR TITLE
new domain for Paris-EST

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -40195,13 +40195,16 @@
   },
   {
     "web_pages": [
-      "http://www.univ-mlv.fr/"
+      "http://www.univ-mlv.fr/",
+      "http://www.u-pem.fr/"
     ],
-    "name": "Université de Marne la Vallée",
+    "name": "Université Paris-Est Marne-la-Vallée",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": [
-      "univ-mlv.fr"
+      "univ-mlv.fr",
+      "u-pem.fr",
+      "etud.u-pem.fr"
     ],
     "country": "France"
   },


### PR DESCRIPTION
I left the old domain in list, it currently redirects to the new domain. The `uted.` subdomain is used for student emails.