### PR TITLE
Add Student email domain for TU Munich

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -43974,7 +43974,8 @@
     "state-province": null,
     "domains": [
       "tum.de",
-      "tum.edu"
+      "tum.edu",
+      "mytum.de"
     ],
     "country": "Germany"
   },


### PR DESCRIPTION
- add "mytum.de" to valid domains according to https://www.it.tum.de/en/it/faq/it-services/e-mail/e-mail-in-general/how-can-i-create-a-tum-e-mail-address-how-can-i-access-my-e-mails/