### PR TITLE
Add Futureworks

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -5078,6 +5078,18 @@
   },
   {
     "web_pages": [
+      "https://futureworks.ac.uk/"
+    ],
+    "name": "Futureworks",
+    "alpha_two_code": "GB",
+    "state-province": null,
+    "domains": [
+      "futureworks.ac.uk"
+    ],
+    "country": "United Kingdom"
+  },
+  {
+    "web_pages": [
       "http://www.gallaudet.edu/"
     ],
     "name": "Gallaudet University",


### PR DESCRIPTION
Adds [Futureworks](https://futureworks.ac.uk/), a university in Manchester, UK