### PR TITLE
Change Universite Pierre et Marie Curie to new name. Added all domains

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -39773,13 +39773,17 @@
   },
   {
     "web_pages": [
-      "http://www.jussieu.fr/"
+      "https://sciences.sorbonne-universite.fr/"
     ],
-    "name": "Université Pierre et Marie Curie (Paris VI)",
+    "name": "Sorbonne Université - Faculté des Sciences (Paris VI)",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": [
-      "jussieu.fr"
+      "jussieu.fr",
+      "etu.upmc.fr",
+      "upmc.fr",
+      "etu.sorbonne-universite.fr",
+      "sorbonne-universite.fr"
     ],
     "country": "France"
   },


### PR DESCRIPTION
Universite Pierre et Marie Curie has changed name to Sorbonne Université - Faculté des sciences after a merger.

Old registered website and domain "jussieu.fr" aren't used for accounts anymore.
Added the domains used for Université Pierre et Marie Curie and added the new domains for Sorbonne Université both are active for now.