### PR TITLE
Added ITU of Pakistan

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -48703,6 +48703,18 @@
   },
   {
     "web_pages": [
+      "https://itu.edu.pk/"
+    ],
+    "name": "Information Technology University, Lahore",
+    "alpha_two_code": "PK",
+    "state-province": "Punjab",
+    "domains": [
+      "itu.edu.pk"
+    ],
+    "country": "Pakistan"
+  },
+  {
+    "web_pages": [
       "https://www.mitindia.edu/en/"
     ],
     "name": "Madras Institute of Technology",


### PR DESCRIPTION
The Information Technology University of Pakistan wasn't there in the list of universities and so I have added it with complete information including the province/state. The university was established in 2012 is quite well-known but for some reason, wasn't there.