### PR TITLE
Change domain for University of Macau

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -70900,13 +70900,13 @@
   },
   {
     "web_pages": [
-      "http://www.umac.mo/"
+      "http://www.um.edu.mo/"
     ],
     "name": "University of Macau",
     "alpha_two_code": "MO",
     "state-province": null,
     "domains": [
-      "umac.mo"
+      "um.edu.mo"
     ],
     "country": "Macao"
   },


### PR DESCRIPTION
University of Macau changed its domain in 2020.
Please accept my pull request.