### PR TITLE
Add Aix-Marseille University.

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -40914,6 +40914,18 @@
   },
   {
     "web_pages": [
+      "http://www.univ-amu.fr/"
+    ],
+    "name": "Université d'Aix-Marseille",
+    "alpha_two_code": "FR",
+    "state-province": null,
+    "domains": [
+      "univ-amu.fr"
+    ],
+    "country": "France"
+  },
+  {
+    "web_pages": [
       "http://www.up.univ-mrs.fr/"
     ],
     "name": "Université de Provence (Aix-Marseille I)",


### PR DESCRIPTION
This is the merger of Aix-Marseille I-III.

See https://en.wikipedia.org/wiki/Aix-Marseille_University#Recent_history_(1968%E2%80%93present), it seems the domains of the other universities are kept around (at least for some departments)