### PR TITLE
Add vub.be as VUB domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -20987,7 +20987,8 @@
     "alpha_two_code": "BE",
     "state-province": null,
     "domains": [
-      "vub.ac.be"
+      "vub.ac.be",
+      "vub.be"
     ],
     "country": "Belgium"
   },


### PR DESCRIPTION
You may notice that https://www.vub.ac.be redirects now to https://www.vub.be, and that `@vub.be` is now the preferred email domain for staff, personnel and students.