### PR TITLE
changed Ghana Polytechnics to Technical University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -45065,7 +45065,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "www.ktu.edu.gh"
+      "ktu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45077,7 +45077,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "www.kstu.edu.gh"
+      "kstu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45137,7 +45137,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "www.ttu.edu.gh"
+      "ttu.edu.gh"
     ],
     "country": "Ghana"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -44915,13 +44915,13 @@
   },
   {
     "web_pages": [
-      "http://www.accrapolytechnic.edu.gh/"
+      "https://atu.edu.gh/"
     ],
-    "name": "Accra Polytechnic",
+    "name": "Accra Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "accrapolytechnic.edu.gh"
+      "https://atu.edu.gh/"
     ],
     "country": "Ghana"
   },
@@ -44975,13 +44975,13 @@
   },
   {
     "web_pages": [
-      "http://www.cpoly.edu.gh/"
+      "https://cctu.edu.gh/"
     ],
-    "name": "Cape Coast Polytechnic",
+    "name": "Cape Coast Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "cpoly.edu.gh"
+      "https://cctu.edu.gh/"
     ],
     "country": "Ghana"
   },
@@ -45023,13 +45023,13 @@
   },
   {
     "web_pages": [
-      "http://www.hopoly.edu.gh/"
+      "https://htu.edu.gh/"
     ],
-    "name": "Ho Polytechnic",
+    "name": "Ho Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "hopoly.edu.gh"
+      "https://htu.edu.gh/"
     ],
     "country": "Ghana"
   },
@@ -45059,25 +45059,25 @@
   },
   {
     "web_pages": [
-      "http://www.koforiduapoly.edu.gh/"
+      "https://www.ktu.edu.gh/"
     ],
-    "name": "Koforidua Polytechnic",
+    "name": "Koforidua Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "koforiduapoly.edu.gh"
+      "https://www.ktu.edu.gh/"
     ],
     "country": "Ghana"
   },
   {
     "web_pages": [
-      "http://www.kpoly.edu.gh/"
+      "https://www.kstu.edu.gh/"
     ],
-    "name": "Kumasi Polytechnic",
+    "name": "Kumasi Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "kpoly.edu.gh"
+      "https://www.kstu.edu.gh/"
     ],
     "country": "Ghana"
   },
@@ -45131,13 +45131,13 @@
   },
   {
     "web_pages": [
-      "http://www.tpoly.edu.gh/"
+      "https://www.ttu.edu.gh/"
     ],
-    "name": "Takoradi Polytechnic",
+    "name": "Takoradi Technical University",
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "tpoly.edu.gh"
+      "https://www.ttu.edu.gh/"
     ],
     "country": "Ghana"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -44921,7 +44921,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://atu.edu.gh/"
+      "atu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -44981,7 +44981,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://cctu.edu.gh/"
+      "cctu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45029,7 +45029,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://htu.edu.gh/"
+      "htu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45065,7 +45065,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://www.ktu.edu.gh/"
+      "www.ktu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45077,7 +45077,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://www.kstu.edu.gh/"
+      "www.kstu.edu.gh"
     ],
     "country": "Ghana"
   },
@@ -45137,7 +45137,7 @@
     "alpha_two_code": "GH",
     "state-province": null,
     "domains": [
-      "https://www.ttu.edu.gh/"
+      "www.ttu.edu.gh"
     ],
     "country": "Ghana"
   },


### PR DESCRIPTION
I live in Ghana and Ghana has changed some of  its polytechnnics to Technical universities. If you want to test the validity you can try loging  onto the changed domains. You will see it is not working no more.