### PR TITLE
Add URJC research groups

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -93581,7 +93581,9 @@
     "alpha_two_code": "ES",
     "state-province": null,
     "domains": [
-      "urjc.es"
+      "urjc.es",
+      "gsyc.es",
+      "libresoft.es"
     ],
     "country": "Spain"
   },


### PR DESCRIPTION
Adding libresoft.es and gsyc.es. Both are Universidad Rey Juan Carlos research groups

Signed-off-by: Pablo Hinojosa <phinojosa@bitergia.com>