### PR TITLE
Latvia University of Life Sciences and Technologies

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -70096,13 +70096,15 @@
   },
   {
     "web_pages": [
-      "http://www.llu.lv/"
+      "https://www.llu.lv/",
+      "https://www.lbtu.lv/"
     ],
-    "name": "Latvian University of Agriculture",
+    "name": "Latvia University of Life Sciences and Technologies",
     "alpha_two_code": "LV",
     "state-province": null,
     "domains": [
-      "llu.lv"
+      "llu.lv",
+      "lbtu.lv"
     ],
     "country": "Latvia"
   },


### PR DESCRIPTION
Previously known as Latvia University of Agriculture.

[..] Since 2018 6th March LLU Senate approved university name in English "Latvia University of Life Sciences and Technologies". [..]
https://www.llu.lv/en/history