### PR TITLE
Update universities in Izmir, Turkey

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -117986,5 +117986,17 @@
       "idu.edu.tr"
     ],
     "country": "Turkey"
+  },
+  {
+    "web_pages": [
+      "https://www.tinaztepe.edu.tr/"
+    ],
+    "name": "Izmir Tınaztepe University",
+    "alpha_two_code": "TR",
+    "state-province": null,
+    "domains": [
+      "tinaztepe.edu.tr"
+    ],
+    "country": "Turkey"
   }
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -105287,13 +105287,15 @@
   },
   {
     "web_pages": [
-      "http://www.ikc.edu.tr/"
+      "http://www.ikc.edu.tr/",
+      "http://www.ikcu.edu.tr/"
     ],
-    "name": "Izmir Katip celebi University",
+    "name": "Izmir Katip Celebi University",
     "alpha_two_code": "TR",
     "state-province": null,
     "domains": [
-      "ikc.edu.tr"
+      "ikc.edu.tr",
+      "ikcu.edu.tr"
     ],
     "country": "Turkey"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -117962,5 +117962,17 @@
       "audencia.com"
     ],
     "country": "France"
+  },
+  {
+    "web_pages": [
+      "https://www.bakircay.edu.tr/"
+    ],
+    "name": "Izmir Bakırçay University",
+    "alpha_two_code": "TR",
+    "state-province": null,
+    "domains": [
+      "bakircay.edu.tr"
+    ],
+    "country": "Turkey"
   }
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -98991,18 +98991,6 @@
   },
   {
     "web_pages": [
-      "http://www.izmirekonomi.edu.tr/"
-    ],
-    "name": "Izmir Economic University",
-    "alpha_two_code": "TR",
-    "state-province": null,
-    "domains": [
-      "izmirekonomi.edu.tr"
-    ],
-    "country": "Turkey"
-  },
-  {
-    "web_pages": [
       "http://www.kafkas.edu.tr/"
     ],
     "name": "Kafkas University",
@@ -105719,13 +105707,15 @@
   },
   {
     "web_pages": [
-      "http://www.ieu.edu.tr/"
+      "http://www.ieu.edu.tr/",
+      "http://www.izmirekonomi.edu.tr/"
     ],
-    "name": "Izmir Economy University",
+    "name": "Izmir University of Economics",
     "alpha_two_code": "TR",
     "state-province": null,
     "domains": [
-      "ieu.edu.tr"
+      "ieu.edu.tr",
+      "izmirekonomi.edu.tr"
     ],
     "country": "Turkey"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -117974,5 +117974,17 @@
       "bakircay.edu.tr"
     ],
     "country": "Turkey"
+  },
+  {
+    "web_pages": [
+      "https://www.idu.edu.tr/"
+    ],
+    "name": "Izmir Democracy University",
+    "alpha_two_code": "TR",
+    "state-province": null,
+    "domains": [
+      "idu.edu.tr"
+    ],
+    "country": "Turkey"
   }
 ]


### PR DESCRIPTION
Updated universities in Izmir, Turkey:

- Removed duplicate Izmir University of Economics, updated the remaining one.
- Updated Izmir Katip Celebi University.
- Added Izmir Bakırçay University.
- Added Izmir Democracy University.
- Added Izmir Tınaztepe University.