### PR TITLE
University of Zurich

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -95272,18 +95272,6 @@
   },
   {
     "web_pages": [
-      "http://www.unizh.ch/"
-    ],
-    "name": "University of Zürich",
-    "alpha_two_code": "CH",
-    "state-province": null,
-    "domains": [
-      "unizh.ch"
-    ],
-    "country": "Switzerland"
-  },
-  {
-    "web_pages": [
       "http://www.victoria-uni.ch/"
     ],
     "name": "Victoria University",
@@ -95402,7 +95390,8 @@
     "alpha_two_code": "CH",
     "state-province": null,
     "domains": [
-      "uzh.ch"
+      "uzh.ch",
+      "unizh.ch"
     ],
     "country": "Switzerland"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -95384,7 +95384,7 @@
   },
   {
     "web_pages": [
-      "http://www.uzh.ch/"
+      "https://www.uzh.ch/"
     ],
     "name": "University of Zurich",
     "alpha_two_code": "CH",


### PR DESCRIPTION
There are currently two entries for the University of Zurich:
* One with the domain [unizh.ch]. This entry exists since the very first commit. This domain belongs to the same university. In fact [unizh.ch] redirects to [uzh.ch].
* One with the domain [uzh.ch]. This entry was added in #72 

I chose to keep the version without umlaut (Zurich instead of Zürich) since that's the spelling the university uses on the [English version of their website](https://www.uzh.ch/en.html).

[unizh.ch]: http://www.unizh.ch
[uzh.ch]: https://uzh.ch