### PR TITLE
Updated Fachhoschule Köln

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -42436,12 +42436,13 @@
   },
   {
     "web_pages": [
-      "http://www.fh-koeln.de/"
+      "https://www.th-koeln.de/"
     ],
-    "name": "Fachhochschule Köln",
+    "name": "Technische Hochschule Köln",
     "alpha_two_code": "DE",
     "state-province": null,
     "domains": [
+	  "th-koeln.de",
       "fh-koeln.de"
     ],
     "country": "Germany"


### PR DESCRIPTION
“Fachhoschule Köln” changed its name to “Technische Hochschule Köln”.
I updated the name, domain, and webpage to the correct values (fh-koeln.de still works, but reroutes to th-koeln.de).

Source: Just graduated from this university.