### PR TITLE
fix: Remove institution that does not exist

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -8017,18 +8017,6 @@
   },
   {
     "web_pages": [
-      "http://www.ntu.edu/"
-    ],
-    "name": "National Technological University",
-    "alpha_two_code": "US",
-    "state-province": null,
-    "domains": [
-      "ntu.edu"
-    ],
-    "country": "United States"
-  },
-  {
-    "web_pages": [
       "http://www.nu.edu/"
     ],
     "name": "National University",


### PR DESCRIPTION
I was not able to find the website for `National Technological University` in the US and the webpage: `http://www.ntu.edu/` does not exist.