### PR TITLE
changed lasu domain to lasu.edu.ng

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -77931,13 +77931,13 @@
   },
   {
     "web_pages": [
-      "http://www.lasunigeria.org/"
+      "http://www.lasu.edu.ng/"
     ],
     "name": "Lagos State University",
     "alpha_two_code": "NG",
     "state-province": null,
     "domains": [
-      "lasunigeria.org"
+      "lasu.edu.ng"
     ],
     "country": "Nigeria"
   },


### PR DESCRIPTION
The website and domain name for Lagos State University is outdated