### PR TITLE
Add student.unisg.ch to Universität St. Gallen (HSG)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -94535,7 +94535,8 @@
       "alpha_two_code": "CH",
       "state-province": null,
       "domains": [
-          "unisg.ch"
+          "unisg.ch",
+          "student.unisg.ch"
       ],
       "country": "Switzerland"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -20827,7 +20827,7 @@
       "alpha_two_code": "BE",
       "state-province": null,
       "domains": [
-          "ulb.be",  
+          "ulb.be",
           "ulb.ac.be"
       ],
       "country": "Belgium"


### PR DESCRIPTION
- Removes trailing whitespace from one entry
- Adds student.unisg.ch which is used for student email addresses in Universität St. Gallen (HSG).