### PR TITLE
Fix the domain for Pakistan/QUEST

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -78900,13 +78900,13 @@
   },
   {
       "web_pages": [
-          "http://www.panasia.org.sg/tcdc/pakistan/qauid_sindh/index.html"
+          "https://quest.edu.pk/"
       ],
       "name": "Qauid-e-Awam University of Engineering Sciences & Technology",
       "alpha_two_code": "PK",
       "state-province": null,
       "domains": [
-          "panasia.org.sg"
+          "quest.edu.pk"
       ],
       "country": "Pakistan"
   },


### PR DESCRIPTION
The "Quaid e Awam University of Engineering, Sciences & Technology" university previously had the domain "panasia.org.sg". DDG[^1] and wikipedia[^2] both agree that the domain name is quest.edu.pk.

From the QUEST webpage clicking "E-mail" redirects to a google email login for the domain quest.edu.pk. So that's the email domain too.

As for removing `panasia.org.sg`, loading that domain shows a "Account Suspended" page.

[^1]: https://duckduckgo.com/?q=Qauid-e-Awam+University+of+Engineering+Sciences+%26+Technology
[^2]: https://en.wikipedia.org/wiki/Quaid-e-Awam_University_of_Engineering,_Science_%26_Technology