### PR TITLE
Add Escola Superior de Media Artes e Design (esmad.ipp.pt)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -119430,5 +119430,13 @@
         "country": "Nigeria",
         "alpha_two_code": "NG",
         "state-province": null
-      }
+    },
+    {
+        "name": "Escola Superior de Media Artes e Design",
+        "domains": ["esmad.ipp.pt", "www.esmad.ipp.pt"],
+        "web_pages": ["https://www.esmad.ipp.pt/"],
+        "country": "Portugal",
+        "alpha_two_code": "PT",
+        "state-province": null
+    }
 ]


### PR DESCRIPTION
Adds esmad.ipp.pt and www.esmad.ipp.pt, two domains for the Escola Superior de Media Artes e Design in Portugal.