### PR TITLE
Change web page and domain for Delaware State University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -4342,13 +4342,13 @@
   },
   {
       "web_pages": [
-          "http://www.dsc.edu/"
+          "http://www.desu.edu/"
       ],
       "name": "Delaware State University",
       "alpha_two_code": "US",
       "state-province": null,
       "domains": [
-          "dsc.edu"
+          "desu.edu"
       ],
       "country": "United States"
   },


### PR DESCRIPTION
## Description:
Change web page and domain for Delaware State University from
-  http://www.dsc.edu/ -> https://www.desu.edu/ 
- dsc.edu -> desu.edu

A simple website check will reveal that the previous web page is incorrect.