### PR TITLE
Update the Istanbul Ticaret University - TR

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -97746,13 +97746,13 @@
   },
   {
       "web_pages": [
-          "http://www.iticu.edu.tr/"
+          "https://ticaret.edu.tr/"
       ],
       "name": "Istanbul Ticaret University",
       "alpha_two_code": "TR",
       "state-province": null,
       "domains": [
-          "iticu.edu.tr"
+          "ticaret.edu.tr"
       ],
       "country": "Turkey"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -97752,7 +97752,8 @@
       "alpha_two_code": "TR",
       "state-province": null,
       "domains": [
-          "ticaret.edu.tr"
+          "ticaret.edu.tr",
+          "istanbulticaret.edu.tr"
       ],
       "country": "Turkey"
   },


### PR DESCRIPTION
- The old `iticu.edu.tr` domain is outdated, changed it to `ticaret.edu.tr`
- Also add student email domain `istanbulticaret.edu.tr`