### PR TITLE
Add additional domain for Open University (UK) used for student email

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -101044,7 +101044,8 @@
       "alpha_two_code": "GB",
       "state-province": null,
       "domains": [
-          "open.ac.uk"
+          "open.ac.uk",
+          "ou.ac.uk"
       ],
       "country": "United Kingdom"
   },


### PR DESCRIPTION
OU uses a different domain for student email. 