### PR TITLE
Fix the name of Taiwan

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -118738,7 +118738,7 @@
         "domains": [
             "csueastbay.edu"
         ],
-        "country": "US"
+        "country": "United States"
     },
     {
         "web_pages": [

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -118438,7 +118438,7 @@
         "domains": [
             "aluno.ifsp.edu.br"
         ],
-        "country": "BR"
+        "country": "Brazil"
     },
     {
         "web_pages": [

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -117372,12 +117372,12 @@
           "https://www.hult.edu/campuses/london/postgraduate/"
       ],
       "name": "HULT Business School",
-      "alpha_two_code": "UK",
+      "alpha_two_code": "GB",
       "state-province": null,
       "domains": [
           "hult.edu"
       ],
-      "country": "UK"
+      "country": "United Kingdom"
   },
   {
       "web_pages": [

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -94863,7 +94863,7 @@
       "domains": [
           "au.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94875,7 +94875,7 @@
       "domains": [
           "ccu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94887,7 +94887,7 @@
       "domains": [
           "cgu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94899,7 +94899,7 @@
       "domains": [
           "chna.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94911,7 +94911,7 @@
       "domains": [
           "chu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94923,7 +94923,7 @@
       "domains": [
           "cju.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94935,7 +94935,7 @@
       "domains": [
           "cku.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94947,7 +94947,7 @@
       "domains": [
           "cmc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94959,7 +94959,7 @@
       "domains": [
           "cpu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94971,7 +94971,7 @@
       "domains": [
           "csmc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94983,7 +94983,7 @@
       "domains": [
           "cycu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -94995,7 +94995,7 @@
       "domains": [
           "cyut.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95007,7 +95007,7 @@
       "domains": [
           "dyu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95019,7 +95019,7 @@
       "domains": [
           "english.web.ncku.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95031,7 +95031,7 @@
       "domains": [
           "fcu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95043,7 +95043,7 @@
       "domains": [
           "fju.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95055,7 +95055,7 @@
       "domains": [
           "hcu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95067,7 +95067,7 @@
       "domains": [
           "hfu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95079,7 +95079,7 @@
       "domains": [
           "isu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95091,7 +95091,7 @@
       "domains": [
           "kmc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95103,7 +95103,7 @@
       "domains": [
           "ksit.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95115,7 +95115,7 @@
       "domains": [
           "ksu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95127,7 +95127,7 @@
       "domains": [
           "kuas.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95139,7 +95139,7 @@
       "domains": [
           "lhu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95151,7 +95151,7 @@
       "domains": [
           "ltc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95163,7 +95163,7 @@
       "domains": [
           "mcu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95175,7 +95175,7 @@
       "domains": [
           "nccu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95187,7 +95187,7 @@
       "domains": [
           "nchu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95199,7 +95199,7 @@
       "domains": [
           "nchulc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95211,7 +95211,7 @@
       "domains": [
           "ncnu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95223,7 +95223,7 @@
       "domains": [
           "ncpes.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95235,7 +95235,7 @@
       "domains": [
           "nctu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95247,7 +95247,7 @@
       "domains": [
           "ncu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95259,7 +95259,7 @@
       "domains": [
           "ncue.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95271,7 +95271,7 @@
       "domains": [
           "ncyu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95283,7 +95283,7 @@
       "domains": [
           "ndhu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95295,7 +95295,7 @@
       "domains": [
           "nfu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95307,7 +95307,7 @@
       "domains": [
           "nhctc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95319,7 +95319,7 @@
       "domains": [
           "nhltc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95331,7 +95331,7 @@
       "domains": [
           "nhu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95343,7 +95343,7 @@
       "domains": [
           "nia.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95355,7 +95355,7 @@
       "domains": [
           "niu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95367,7 +95367,7 @@
       "domains": [
           "nkfu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95379,7 +95379,7 @@
       "domains": [
           "nknu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95391,7 +95391,7 @@
       "domains": [
           "nou.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95403,7 +95403,7 @@
       "domains": [
           "npttc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95415,7 +95415,7 @@
       "domains": [
           "npust.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95427,7 +95427,7 @@
       "domains": [
           "nsysu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95439,7 +95439,7 @@
       "domains": [
           "ntca.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95451,7 +95451,7 @@
       "domains": [
           "ntcn.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95463,7 +95463,7 @@
       "domains": [
           "ntcpe.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95475,7 +95475,7 @@
       "domains": [
           "ntctc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95487,7 +95487,7 @@
       "domains": [
           "nthu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95499,7 +95499,7 @@
       "domains": [
           "ntntc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95511,7 +95511,7 @@
       "domains": [
           "ntnu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95523,7 +95523,7 @@
       "domains": [
           "ntou.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95535,7 +95535,7 @@
       "domains": [
           "ntptc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95547,7 +95547,7 @@
       "domains": [
           "ntpu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95559,7 +95559,7 @@
       "domains": [
           "ntttc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95571,7 +95571,7 @@
       "domains": [
           "ntu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95584,7 +95584,7 @@
           "ntust.edu.tw",
           "gapps.ntust.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95596,7 +95596,7 @@
       "domains": [
           "ntut.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95608,7 +95608,7 @@
       "domains": [
           "nuk.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95620,7 +95620,7 @@
       "domains": [
           "nuu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95632,7 +95632,7 @@
       "domains": [
           "ouk.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95644,7 +95644,7 @@
       "domains": [
           "pccu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95656,7 +95656,7 @@
       "domains": [
           "pu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95668,7 +95668,7 @@
       "domains": [
           "scc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95680,7 +95680,7 @@
       "domains": [
           "scu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95692,7 +95692,7 @@
       "domains": [
           "shu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95704,7 +95704,7 @@
       "domains": [
           "sjsmit.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95716,7 +95716,7 @@
       "domains": [
           "stut.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95728,7 +95728,7 @@
       "domains": [
           "tcu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95740,7 +95740,7 @@
       "domains": [
           "thmu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95752,7 +95752,7 @@
       "domains": [
           "thu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95764,7 +95764,7 @@
       "domains": [
           "tku.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95776,7 +95776,7 @@
       "domains": [
           "tmc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95788,7 +95788,7 @@
       "domains": [
           "tmtc.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95800,7 +95800,7 @@
       "domains": [
           "tnca.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95812,7 +95812,7 @@
       "domains": [
           "tpec.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95824,7 +95824,7 @@
       "domains": [
           "ttit.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95836,7 +95836,7 @@
       "domains": [
           "ttu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95848,7 +95848,7 @@
       "domains": [
           "ym.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95860,7 +95860,7 @@
       "domains": [
           "yuntech.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -95872,7 +95872,7 @@
       "domains": [
           "yzu.edu.tw"
       ],
-      "country": "Taiwan"
+      "country": "Taiwan, Province of China"
   },
   {
       "web_pages": [
@@ -118294,7 +118294,7 @@
     "domains": [
     "ltu.edu.tw"
     ],
-    "country": "Taiwan"
+    "country": "Taiwan, Province of China"
   },
   {
     "web_pages": [


### PR DESCRIPTION
For the consistency between this project and the pycountry ISO databases, revert to Taiwan's name to "Taiwan, Province of China".

Refer to [1] for more details.

[1] https://github.com/pycountry/pycountry/blob/main/src/pycountry/databases/iso3166-1.json