### PR TITLE
Remove high school and vocational school

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -3647,14 +3647,6 @@
       "country": "United States"
   },
   {
-    "web_pages": ["https://www.hallco.org/"],
-    "name": "Hall County Schools",
-    "alpha_two_code": "US",
-    "state-province": null,
-    "domains": ["hallco.org"],
-    "country": "United States"
-  },
-  {
       "web_pages": [
           "http://www.clayton.edu/"
       ],
@@ -40918,18 +40910,6 @@
       "state-province": null,
       "domains": [
           "akad.de"
-      ],
-      "country": "Germany"
-  },
-  {
-      "web_pages": [
-          "http://www.bsaoe.de/"
-      ],
-      "name": "Berufliche Schulen Altötting",
-      "alpha_two_code": "DE",
-      "state-province": null,
-      "domains": [
-          "bsaoe.de"
       ],
       "country": "Germany"
   },


### PR DESCRIPTION
### Intention
- Removing Hall County Schools and Berufliche Schulen Altötting which are high schools/vocational schools.
- This undoes the PRs (https://github.com/Hipo/university-domains-list/pull/547 & https://github.com/Hipo/university-domains-list/pull/548 )
- This issue is also referenced here: https://github.com/Hipo/university-domains-list/issues/550
