### PR TITLE
Add nkust.edu.tw

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -95194,18 +95194,6 @@
   },
   {
       "web_pages": [
-          "http://www.kuas.edu.tw/"
-      ],
-      "name": "National Kaohsiung University of Applied Sciences",
-      "alpha_two_code": "TW",
-      "state-province": null,
-      "domains": [
-          "kuas.edu.tw"
-      ],
-      "country": "Taiwan, Province of China"
-  },
-  {
-      "web_pages": [
           "http://www.lhu.edu.tw/"
       ],
       "name": "LungHwa University of Science and Technology",
@@ -95422,13 +95410,13 @@
   },
   {
       "web_pages": [
-          "http://www.nkfu.edu.tw/"
+          "https://www.nkust.edu.tw/"
       ],
-      "name": "National Kaohsiung First University of Science and Technology",
+      "name": "National Kaohsiung University of Science and Technology",
       "alpha_two_code": "TW",
       "state-province": null,
       "domains": [
-          "nkfu.edu.tw"
+          "nkust.edu.tw"
       ],
       "country": "Taiwan, Province of China"
   },


### PR DESCRIPTION
After the merger that took place after February 1, 2018, which combined National Kaohsiung University of Applied Sciences, National Kaohsiung First University of Science and Technology, and National Kaohsiung Marine University into National Kaohsiung University of Science and Technology, I have removed 'kuas' and 'NKFUST', and added 'NKUST'. It appears that 'NKMU' had no existing data initially, so no modifications were made.