### PR TITLE
Added students email domain name to the domain list for University Co…

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -56188,7 +56188,8 @@
       "alpha_two_code": "IE",
       "state-province": null,
       "domains": [
-          "ucd.ie"
+          "ucd.ie",
+          "ucdconnect.ie"
       ],
       "country": "Ireland"
   },


### PR DESCRIPTION
The domain name for students attending University College Dublin, Ireland was missing.

The existing domain name was the email domain name for staff. 

I added students email domain name to the domain: ucdconnect.ie.