### PR TITLE
Update state/province of Istanbul Ticaret University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -97854,7 +97854,7 @@
       ],
       "name": "Istanbul Ticaret University",
       "alpha_two_code": "TR",
-      "state-province": null,
+      "state-province": "Istanbul",
       "domains": [
           "ticaret.edu.tr",
           "istanbulticaret.edu.tr"


### PR DESCRIPTION
I set the state/province value to "Istanbul". Normally, the name Istanbul is called `İstanbul` in the Turkish alphabet, but I wrote it with `I` for compatibility.