### PR TITLE
Added a new domain for IIT

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -6078,7 +6078,8 @@
       "alpha_two_code": "US",
       "state-province": null,
       "domains": [
-          "iit.edu"
+          "iit.edu",
+          "hawk.iit.edu"
       ],
       "country": "United States"
   },


### PR DESCRIPTION
Added a new domain for Illinois Institute of Technology. Used to go there and this is the new student domain listing.