### PR TITLE
University Polsdam doesn't exist, probably mistaken by University Potsdam

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -29432,14 +29432,6 @@
     "country": "Germany"
   },
   {
-    "web_pages": ["http://www.uni-polsdam.de/"],
-    "name": "Universität Polsdam",
-    "alpha_two_code": "DE",
-    "state-province": null,
-    "domains": ["uni-polsdam.de"],
-    "country": "Germany"
-  },
-  {
     "web_pages": ["http://www.uni-regensburg.de/"],
     "name": "Universität Regensburg",
     "alpha_two_code": "DE",


### PR DESCRIPTION
I searched google and duckduckgo, they all give same suggestion, and the domain doesn't exist either