### PR TITLE
Updated data entry for University Of Galway

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -37552,11 +37552,11 @@
     "country": "Ireland"
   },
   {
-    "web_pages": ["https://www.nuigalway.ie/", "http://www.ucg.ie/"],
-    "name": "National University of Ireland, Galway",
+    "web_pages": ["https://www.universityofgalway.ie/","https://www.nuigalway.ie/", "http://www.ucg.ie/"],
+    "name": "University of Galway",
     "alpha_two_code": "IE",
     "state-province": null,
-    "domains": ["nuigalway.ie", "ucg.ie"],
+    "domains": ["universityofgalway.ie","nuigalway.ie", "ucg.ie"],
     "country": "Ireland"
   },
   {


### PR DESCRIPTION
Renamed National University of Ireland, Galway after the recent rebrand of the college along with its new domain name.

New domain:
https://www.universityofgalway.ie/

Source: 
https://www.rte.ie/news/connacht/2022/0427/1294705-nui-galway-name/