### PR TITLE
Pylint alerts corrections as part of intervention experiment

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -15,11 +15,7 @@ def _country_filter(src, scope, out):
     def filter(entry, item):
         matching = entry["country"]
 
-        if item == matching or item == matching.lower() or item == matching.upper():
-            return True
-
-        else:
-            return False
+        return item == matching or item == matching.lower() or item == matching.upper()
 
     return [entry for entry in src if filter(entry, scope)]
 


### PR DESCRIPTION
The PR takes care of intervention for this [issue](https://github.com/Hipo/university-domains-list/issues/666) as part of an experiment.
The experiment is detailed [here](https://github.com/evidencebp/pylint-intervention)

Code uses the pattern
if test:
    return True
else:
   return False

Pylint alerts on that and suggest a simplification: The if statement can be replaced with 'return bool(test)' (simplifiable-if-statement)

Hence I removed the if and instead returned the test directly.

That simplifies the code and makes it easier to understand.