### PR TITLE
Add dpt-info.u-strasbg.fr domain for Université De Strasbourg

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -27119,7 +27119,7 @@
     "name": "Université de Strasbourg",
     "alpha_two_code": "FR",
     "state-province": null,
-    "domains": ["unistra.fr", "etu.unistra.fr"],
+    "domains": ["unistra.fr", "etu.unistra.fr", "dpt-info.u-strasbg.fr"],
     "country": "France"
   },
   {


### PR DESCRIPTION
The computer science department uses that URL.