### PR TITLE
Fix belarusian universities' names

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -13454,7 +13454,7 @@
   },
   {
     "web_pages": ["https://baa.by/"],
-    "name": "Belarussian State Agricultural Academy",
+    "name": "Belarusian State Agricultural Academy",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["baa.by"],
@@ -13462,7 +13462,7 @@
   },
   {
     "web_pages": ["https://www.bsatu.by/"],
-    "name": "Belarussian State Agrarian Technical University",
+    "name": "Belarusian State Agrarian Technical University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["batu.edu.by"],
@@ -13470,7 +13470,7 @@
   },
   {
     "web_pages": ["https://www.bsut.by/"],
-    "name": "Belarussian State University of Transport",
+    "name": "Belarusian State University of Transport",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["belsut.gomel.by"],
@@ -13478,7 +13478,7 @@
   },
   {
     "web_pages": ["https://bgam.by/"],
-    "name": "Belarussian State Academy of Music",
+    "name": "Belarusian State Academy of Music",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bgam.edu.by"],
@@ -13486,7 +13486,7 @@
   },
   {
     "web_pages": ["https://bntu.by/"],
-    "name": "Belarussian National Technical University",
+    "name": "Belarusian National Technical University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bntu.by"],
@@ -13510,7 +13510,7 @@
   },
   {
     "web_pages": ["http://bseu.by/"],
-    "name": "Belarussian State Economic University",
+    "name": "Belarusian State Economic University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bseu.by"],
@@ -13518,7 +13518,7 @@
   },
   {
     "web_pages": ["https://bsmu.by/"],
-    "name": "Belarussian State Medical University",
+    "name": "Belarusian State Medical University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bsmu.by"],
@@ -13526,7 +13526,7 @@
   },
   {
     "web_pages": ["https://bspu.by/"],
-    "name": "Belarussian State Pedagogical University M. Tanka",
+    "name": "Belarusian State Pedagogical University M. Tanka",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bspu.unibel.by"],
@@ -13542,7 +13542,7 @@
   },
   {
     "web_pages": ["https://belstu.by/"],
-    "name": "Belarussian State Technological University",
+    "name": "Belarusian State Technological University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bstu.unibel.by"],
@@ -13550,7 +13550,7 @@
   },
   {
     "web_pages": ["https://bsu.by/"],
-    "name": "Belarussian State University",
+    "name": "Belarusian State University",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bsu.by"],
@@ -13558,7 +13558,7 @@
   },
   {
     "web_pages": ["https://www.bsuir.by/"],
-    "name": "Belarussian State University of Informatics and Radioelectronics",
+    "name": "Belarusian State University of Informatics and Radioelectronics",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["bsuir.by"],
@@ -13566,7 +13566,7 @@
   },
   {
     "web_pages": ["https://www.buk.by/"],
-    "name": "Belarussian State University of Culture and Arts",
+    "name": "Belarusian State University of Culture and Arts",
     "alpha_two_code": "BY",
     "state-province": null,
     "domains": ["buk.by"],


### PR DESCRIPTION
I've corrected the spelling of some belarusian university names.
Removed the redundant `s` from the word `Belarusian`.
Spelling could be checked in wikipedia https://en.wikipedia.org/wiki/List_of_universities_in_Belarus or in English versions of university pages (for example https://bsu.by/en/).