### PR TITLE
Add domain for Pukyong National University: pukyong.ac.kr 

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -45344,7 +45344,7 @@
     "name": "Pukyong National University",
     "alpha_two_code": "KR",
     "state-province": null,
-    "domains": ["pknu.ac.kr"],
+    "domains": ["pknu.ac.kr", "pukyong.ac.kr"],
     "country": "Korea, Republic of"
   },
   {


### PR DESCRIPTION
Pukyong National University have mail domain for students: `pukyong.ac.kr`.

https://mail.pukyong.ac.kr:8443/main/main.jsp