### PR TITLE
updated nsit to nsut as per govt of nct of delhi 

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -33056,11 +33056,11 @@
     "country": "India"
   },
   {
-    "web_pages": ["http://www.nsit.ac.in/"],
-    "name": "Netaji Subhas Institute of Technology",
+    "web_pages": ["http://www.nsut.ac.in/"],
+    "name": "Netaji Subhas University of Technology",
     "alpha_two_code": "IN",
-    "state-province": null,
-    "domains": ["nsit.ac.in"],
+    "state-province": "Delhi",
+    "domains": ["nsut.ac.in"],
     "country": "India"
   },
   {


### PR DESCRIPTION
NSIT WAS RENAMED TO NSUT AS PER
"Delhi Netaji Subhas University of Technology Act, 2017 (DELHI ACT 06 of 2018)"