### PR TITLE
fix: name for Universidad Distrital in Colombia

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -21750,7 +21750,7 @@
   },
   {
     "web_pages": ["http://www.udistrital.edu.co/"],
-    "name": "Universidad Distral \"Francisco José de Caldas\"",
+    "name": "Universidad Distrital \"Francisco José de Caldas\"",
     "alpha_two_code": "CO",
     "state-province": null,
     "domains": ["udistrital.edu.co"],


### PR DESCRIPTION
Currently the name "Universidad Distral " appears, but it should be "Universidad Distrital"