### PR TITLE
Update Université de Lille entries post-merger

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -26652,7 +26652,7 @@
   },
   {
     "web_pages": ["http://www.univ-lille1.fr/"],
-    "name": "Université des Sciences et Technologies de Lille (Lille I)",
+    "name": "Université des Sciences et Technologies de Lille (Lille I) | Old",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-lille1.fr"],
@@ -26660,7 +26660,7 @@
   },
   {
     "web_pages": ["http://www.univ-lille2.fr/"],
-    "name": "Université du Droit et de la Sante (Lille II)",
+    "name": "Université du Droit et de la Sante (Lille II) | Old",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-lille2.fr"],
@@ -26668,10 +26668,18 @@
   },
   {
     "web_pages": ["http://www.univ-lille3.fr/"],
-    "name": "Université Charles-de-Gaulle (Lille III)",
+    "name": "Université Charles-de-Gaulle (Lille III) | Old",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-lille3.fr"],
+    "country": "France"
+  },
+  {
+    "web_pages": ["http://www.univ-lille.fr/"],
+    "name": "Université de Lille)",
+    "alpha_two_code": "FR",
+    "state-province": null,
+    "domains": ["univ-lille.fr"],
     "country": "France"
   },
   {
@@ -81494,5 +81502,4 @@
     "alpha_two_code": "IN",
     "state-province": "Telangana"
   }
-
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -26676,7 +26676,7 @@
   },
   {
     "web_pages": ["http://www.univ-lille.fr/"],
-    "name": "Université de Lille)",
+    "name": "Université de Lille",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-lille.fr"],


### PR DESCRIPTION
# Update Université de Lille entries post-merger

As a current student at **Université de Lille**, I noticed that the dataset still lists the former institutions separately:

- Université des Sciences et Technologies de Lille (Lille I)
- Université du Droit et de la Santé (Lille II)
- Université Charles-de-Gaulle (Lille III)

These three universities officially merged in 2018 into a single entity: **Université de Lille**  
[Source – Wikipedia](https://en.wikipedia.org/wiki/University_of_Lille)

## Changes made

- Appended `"Old"` to the names of Lille I, II, and III to indicate their historical status.
- Added a new, consolidated entry for **Université de Lille** with the current domain: `www.univ-lille.fr`.

This ensures the dataset reflects the current institutional structure and avoids confusion for students and developers relying on up-to-date university data.