### PR TITLE
Update university data for a couple of institutions

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -33084,7 +33084,7 @@
     "name": "Pandit Deendayal Energy University",
     "alpha_two_code": "IN",
     "state-province": "Gujarat",
-    "domains": ["pdeu.ac.in"],
+    "domains": ["pdeu.ac.in", "pdpu.ac.in"],
     "country": "India"
   },
   {

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -33080,7 +33080,7 @@
     "country": "India"
   },
   {
-    "web_pages": ["http://www.pdeu.ac.in/", "http://www.pdpu.ac.in/"],
+    "web_pages": ["https://www.pdeu.ac.in/", "https://www.pdpu.ac.in/"],
     "name": "Pandit Deendayal Energy University",
     "alpha_two_code": "IN",
     "state-province": "Gujarat",

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -32819,7 +32819,7 @@
     "web_pages": ["http://www.nirmauni.ac.in/"],
     "name": "Nirma University",
     "alpha_two_code": "IN",
-    "state-province": null,
+    "state-province": "Gujarat",
     "domains": ["nirmauni.ac.in"],
     "country": "India"
   },
@@ -33080,11 +33080,11 @@
     "country": "India"
   },
   {
-    "web_pages": ["http://www.pdpu.ac.in/"],
-    "name": "Pandit Deendayal Petroleum University",
+    "web_pages": ["http://www.pdeu.ac.in/", "http://www.pdpu.ac.in/"],
+    "name": "Pandit Deendayal Energy University",
     "alpha_two_code": "IN",
-    "state-province": null,
-    "domains": ["pdpu.ac.in"],
+    "state-province": "Gujarat",
+    "domains": ["pdeu.ac.in"],
     "country": "India"
   },
   {


### PR DESCRIPTION
- Set 'state-province' to 'Gujarat' for Nirma University and Pandit Deendayal Energy University.

- Updated Pandit Deendayal's name, domains, and web pages to reflect its current status. It is now "Pandit Deendayal Energy University". the http://www.pdpu.ac.in/ webpage just redirects you now to http://www.pdeu.ac.in/ . I kept both since that does still work.