### PR TITLE
Add ESOFT Uni (Sri Lanka) to world university domains list

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -62127,7 +62127,7 @@
     "web_pages": ["https://esoft.lk/", "https://www.esu.lk/"],
     "name": "ESOFT Uni",
     "alpha_two_code": "LK",
-    "state-province": null,
+    "state-province": "Western Province",
     "domains": ["esoft.academy"],
     "country": "Sri Lanka"
   },


### PR DESCRIPTION
This PR adds ESOFT Uni (formerly ESOFT Metro Campus) to the `world_universities_and_domains.json` dataset, reflecting its updated name usage and digital identity.

University Details:
+ Name: ESOFT Uni
+ Country: Sri Lanka
+ Alpha-2 Code: LK
+ Domains: esoft.academy
+ Web Pages:
  + https://esoft.lk/
  + https://www.esu.lk/

Justification:
+ The domain esoft.academy is used for student email addresses and official academic communications, fulfilling the criteria for domain inclusion.
+ ESOFT Uni (formerly ESOFT Metro Campus) is an established provider of accredited undergraduate and postgraduate programs across Sri Lanka.