### PR TITLE
(fix) Fixed typo for Universitat Ramon Llull

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -61341,7 +61341,7 @@
   },
   {
     "web_pages": ["http://www.salleurl.edu/"],
-    "name": "La Salle - Universitat Rámon Llull",
+    "name": "La Salle - Universitat Ramon Llull",
     "alpha_two_code": "ES",
     "state-province": null,
     "domains": ["salleurl.edu"],
@@ -61837,7 +61837,7 @@
   },
   {
     "web_pages": ["http://www.url.es/"],
-    "name": "Universitat Rámon Llull",
+    "name": "Universitat Ramon Llull",
     "alpha_two_code": "ES",
     "state-province": null,
     "domains": ["url.es"],


### PR DESCRIPTION
The name for the University "Universitat Ramon Llull" does not actually have an accent in the word "Ramon" as seen in the official site: https://www.url.edu/.

Regards,  
Iscle