### PR TITLE
Add domain to Bocconi University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -38064,7 +38064,7 @@
     "name": "Bocconi University",
     "alpha_two_code": "IT",
     "state-province": null,
-    "domains": ["unibocconi.it"],
+    "domains": ["unibocconi.it", "studbocconi.it"],
     "country": "Italy"
   },
   {


### PR DESCRIPTION
@unibocconi.it is only used for Professor/PhD candidate emails, @studbocconi.it is the email domain used by undergraduate/graduate students.

For reference:
https://www.whois.com/whois/studbocconi.it
https://didattica.unibocconi.it/tsg/testo.php?idr=12387&comando=Apri&edizione=2017&volume=N3&idAnt=12387&strperc=1.