### PR TITLE
Update Tecnologico de Monterrey details, including state-province.

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -48431,7 +48431,7 @@
     "web_pages": ["https://www.tec.mx/"],
     "name": "Tecnologico de Monterrey",
     "alpha_two_code": "MX",
-    "state-province": null,
+    "state-province": "NL",
     "domains": ["tec.mx"],
     "country": "Mexico"
   },


### PR DESCRIPTION
Updated details for Tecnologico de Monterrey to reflect current branding: the university shortened its official name and updated its domain. The new domain is now "tec.mx" instead of "itesm.mx" (which no longer works).