### PR TITLE
Added Minerva University

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -28782,7 +28782,7 @@
     "state-province": null,
     "domains": ["mu-luebeck.de"],
     "country": "Germany"
-  },
+  },  
   {
     "web_pages": ["http://www.muthesius.de/"],
     "name": "Muthesius-Hochschule, Fachhochschule für Kunst und Gestaltung",
@@ -70185,6 +70185,14 @@
     "alpha_two_code": "US",
     "state-province": null,
     "domains": ["gccaz.edu"],
+    "country": "United States"
+  },
+  {
+    "web_pages": ["https://www.minerva.edu/"],
+    "name": "Minerva University",
+    "alpha_two_code": "US",
+    "state-province": "CA",
+    "domains": ["minerva.edu"],
     "country": "United States"
   },
   {


### PR DESCRIPTION
Added Minerva University, based in San Francisco.
Official Website: https://www.minerva.edu/
Wikipedia Page: https://en.wikipedia.org/wiki/Minerva_University