### PR TITLE
Add South Metropolitan TAFE domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -12021,6 +12021,14 @@
     "country": "Australia"
   },
   {
+    "web_pages": ["https://www.southmetrotafe.wa.edu.au/"],
+    "name": "South Metropolitan TAFE",
+    "alpha_two_code": "AU",
+    "state-province": "Western Australia",
+    "domains": ["smtafe.wa.edu.au"],
+    "country": "Australia"
+  },
+  {
     "web_pages": ["http://www.scu.edu.au/"],
     "name": "Southern Cross University",
     "alpha_two_code": "AU",
@@ -77755,11 +77763,11 @@
     "country": "India"
   },
   {
-    "web_pages": ["https://coeruniversity.ac.in","https://coer.ac.in/"],
+    "web_pages": ["https://coeruniversity.ac.in", "https://coer.ac.in/"],
     "name": "COER University Roorkee",
     "alpha_two_code": "IN",
     "state-province": "Uttarakhand",
-    "domains": [ "coeruniversity.ac.in", "coer.ac.in"],
+    "domains": ["coeruniversity.ac.in", "coer.ac.in"],
     "country": "India"
   },
   {


### PR DESCRIPTION
This PR adds the domain for South Metropolitan TAFE (SMTAFE) in Western Australia.

- Institution: South Metropolitan TAFE  
- Domain: smtafe.wa.edu.au
- Website: https://www.southmetrotafe.wa.edu.au/
- Location: Western Australia, Australia

The entry has been added in the correct alphabetical position and follows the existing format for Australian institutions.