### PR TITLE
Addition of tafe.wa.edu.au domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -12025,7 +12025,7 @@
     "name": "South Metropolitan TAFE",
     "alpha_two_code": "AU",
     "state-province": "Western Australia",
-    "domains": ["smtafe.wa.edu.au", "southmetrotafe.wa.edu.au", "tafe.wa.edu.au",],
+    "domains": ["smtafe.wa.edu.au", "southmetrotafe.wa.edu.au", "tafe.wa.edu.au"],
     "country": "Australia"
   },
   {


### PR DESCRIPTION
based on previous PR here: https://github.com/Hipo/university-domains-list/pull/770

Appears staff have SMTAFE domains (which is included in the domain list currently) but students only have TAFE