### PR TITLE
fix: correct name of Universidade Catolica de Salvador

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -14950,7 +14950,7 @@
   },
   {
     "web_pages": ["http://www.ucsal.br/"],
-    "name": "Universidade Católica de Salvador",
+    "name": "Universidade Católica do Salvador",
     "alpha_two_code": "BR",
     "state-province": null,
     "domains": ["ucsal.br", "ucsal.edu.br"],

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -14952,7 +14952,7 @@
     "web_pages": ["http://www.ucsal.br/"],
     "name": "Universidade Católica do Salvador",
     "alpha_two_code": "BR",
-    "state-province": null,
+    "state-province": "Salvador",
     "domains": ["ucsal.br", "ucsal.edu.br"],
     "country": "Brazil"
   },


### PR DESCRIPTION
* Corrected the university name from "Universidade Católica de Salvador" to "Universidade Católica do Salvador" in `world_universities_and_domains.json`.