### PR TITLE
Add BIIE institution

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "Botnar Institute of Immune Engineering",
+    "domains": ["immune.engineering"],
+    "web_pages": ["https://immune.engineering"],
+    "country": "Switzerland",
+    "alpha_two_code": "CH",
+    "state-province": "Basel-Landschaft"
+  },
+  {
     "name": "Hellenic College of Noah",
     "domains": ["noah.edu.gr"],
     "web_pages": ["https://noah.edu.gr"],


### PR DESCRIPTION
BIIE stands for Botnar Institute of Immune Engineering and is a non-profit organization affiliated with ETH Zurich and Oxford University [https://immune.engineering](https://immune.engineering)