### PR TITLE
Fix SUNY Broome Community College domain, URL, and state-province

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -74615,7 +74615,7 @@
     "web_pages": ["https://sunybroome.edu/"],
     "name": "SUNY Broome Community College",
     "alpha_two_code": "US",
-    "state-province": null,
+    "state-province": "New York",
     "domains": ["sunybroome.edu"],
     "country": "United States"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -74612,7 +74612,7 @@
     "country": "United States"
   },
   {
-    "web_pages": ["http://WWW.SUNYBROOME.EDU"],
+    "web_pages": ["https://sunybroome.edu/"],
     "name": "SUNY Broome Community College",
     "alpha_two_code": "US",
     "state-province": null,

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -74616,7 +74616,7 @@
     "name": "SUNY Broome Community College",
     "alpha_two_code": "US",
     "state-province": null,
-    "domains": ["www.sunybroome.edu"],
+    "domains": ["sunybroome.edu"],
     "country": "United States"
   },
   {


### PR DESCRIPTION
This PR fixes the entry for SUNY Broome Community College.

- Institution: SUNY Broome Community College
- Domain: `www.sunybroome.edu` → `sunybroome.edu`
- Website: `http://WWW.SUNYBROOME.EDU` → `https://sunybroome.edu/`
- State-province: `null` → `New York`
- Location: Binghamton, New York, United States

The `www.` prefix in the domains field prevents email domain matching from correctly identifying `@sunybroome.edu` addresses as belonging to this institution. The web_pages URL has also been updated to the current HTTPS address, and the missing state-province has been populated.