### PR TITLE
Update Bogazici University domain

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -65468,11 +65468,11 @@
     "country": "Turkiye"
   },
   {
-    "web_pages": ["http://www.boun.edu.tr/"],
+    "web_pages": ["https://www.bogazici.edu.tr/"],
     "name": "Boğaziçi University",
     "alpha_two_code": "TR",
     "state-province": null,
-    "domains": ["boun.edu.tr"],
+    "domains": ["bogazici.edu.tr"],
     "country": "Turkiye"
   },
   {


### PR DESCRIPTION
The domain for Bogazici University is no longer "boun.edu.tr".

The university has migrated to "bogazici.edu.tr", and institutional email addresses now use subdomains such as:

- std.bogazici.edu.tr (students)
- pt.bogazici.edu.tr (part-time staff)
- bogazici.edu.tr (personnel)

Since this repository stores only root domains, this PR updates the domain to:

- bogazici.edu.tr

Official website: [Bogazici University](https://www.bogazici.edu.tr/)

Additional evidence is attached (login screen of [BUMail](https://bumail.bogazici.edu.tr/) showing updated email domains).

<img width="1461" height="827" alt="bumail" src="https://github.com/user-attachments/assets/22a85bb6-3249-4145-a643-c1c6901cf4f8" />