### PR TITLE
Update ESC Clermont to Clermont School of Business

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -26141,11 +26141,11 @@
     "country": "France"
   },
   {
-    "web_pages": ["http://www.esc-clermont.fr/"],
-    "name": "Ecole Supérieure de Commerce de Clermont-Ferrand",
+    "web_pages": ["http://www.clermont-sb.fr/"],
+    "name": "Clermont School of Business",
     "alpha_two_code": "FR",
     "state-province": null,
-    "domains": ["esc-clermont.fr"],
+    "domains": ["clermont-sb.fr"],
     "country": "France"
   },
   {


### PR DESCRIPTION
I noticed issue #782 reporting that ESC Clermont (Ecole Supérieure de Commerce de Clermont-Ferrand) has rebranded to Clermont School of Business. The current entry still references the old name and the `esc-clermont.fr` domain, which no longer reflects the school's identity.

This PR updates three fields in the JSON entry — `name`, `domains`, and `web_pages` — to match the school's new branding as "Clermont School of Business" with the domain `clermont-sb.fr`. The rebrand is documented publicly, for example in [this article](https://schoolsandagents.com/membersarticle/clermont-business-school) referenced in the issue.

No structural changes to the JSON file — just the data for this one entry.

Closes #782