### PR TITLE
Improve contribution guide and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,8 +66,10 @@ Troubleshooting: Test failures almost always mean you introduced a duplicate dom
 To further ensure your modifications are accepted seamlessly, always validate your intent against these domain rules:
 
 - **Internet Validation (If Applicable):** If you are equipped with internet access or web search capabilities, always search for the university online to validate the correctness of its name, domain, and primary web page before proposing an addition or modification. Ensure the domain actively resolves to the stated institution.
-- **Root Domains Only:** Universities often use subdomains for departments or student email scopes (e.g., student@cs.usc.edu). The dataset must only contain the root domain (usc.edu).
-- **No Protocols in Domains:** The domains array should consist strictly of domain names without prefixes (e.g., sabanciuniv.edu, not http://www.sabanciuniv.edu).
-- **Web Pages Array:** Unlike domains, strings in the web_pages array must include the protocol (e.g., http://www.sabanciuniv.edu/).
+- **Root Domains Only (`domains` field):** Universities often use subdomains for departments or student email scopes (e.g., `student@cs.usc.edu`). The `domains` array must only contain the root domain (e.g., `usc.edu`, not `cs.usc.edu`). This restriction applies **only to `domains`**, not to `web_pages`.
+- **No Protocols in Domains:** The `domains` array must contain bare domain names without any protocol prefix (e.g., `sabanciuniv.edu`, not `http://www.sabanciuniv.edu`).
+- **Web Pages Array:** The `web_pages` array must include the protocol and may point to any valid URL, including subdomains (e.g., `https://newsite.university.edu/`). Prefer `https://` over `http://`; only use `http://` if the site does not support HTTPS. URLs must end with a trailing slash.
+- **University Name:** For universities using a Latin-alphabet language (French, German, Spanish, Turkish, etc.), use the official name in the original language including native characters (e.g., `Boğaziçi University`, `Université Paris-Saclay`). For non-Latin scripts (Arabic, Chinese, Cyrillic, etc.), use the official English name or a standard romanized transliteration.
+- **Country Field:** Use the full English country name following ISO 3166-1 English short names (e.g., `"Turkey"`, not `"Türkiye"` or `"Deutschland"`).
 
 **When to Search:** Rely strictly on the paths and commands provided here. Only use grep, find, or repository searches if the validation test suite fails due to missing files, or if the Python environment indicates missing upstream dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ All university data is stored in `world_universities_and_domains.json`. When add
   - `name`: Official name of the university (see naming rules below).
   - `country`: Full country name in English, following [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) English short names (e.g., `"Germany"`, not `"Deutschland"`).
   - `alpha_two_code`: Standard ISO 3166-1 alpha-2 code (e.g., `"US"`, `"TR"`).
-  - `domains`: An array of strings (even if there is only one).
-  - `web_pages`: An array of strings (even if there is only one). Must begin with `https://` (preferred). Only use `http://` if the university's site does not support HTTPS. Must end with a trailing slash (e.g., `https://www.boun.edu.tr/`).
+  - `domains`: An array of root domain strings only — no subdomains (see critical note below).
+  - `web_pages`: An array of URL strings (even if there is only one). May point to any valid URL including subdomains (e.g., `https://newsite.university.edu/`). Must begin with `https://` (preferred). Only use `http://` if the university's site does not support HTTPS. Must end with a trailing slash.
   - `state-province`: State or province name in English. Use `null` if not applicable.
 - **Accuracy:** Ensure the domains and web pages are currently active.
 - **No Duplicates:** Check if the university already exists under a different name or variation.
@@ -55,13 +55,15 @@ Use the official English name. If no official English name exists, use a standar
 }
 ```
 
-> **⚠️ CRITICAL: ROOT DOMAINS ONLY**
-> Some universities use formats like `[user]@[department].[domain]`. This list MUST only contain the `[domain]` portion.
+> **⚠️ CRITICAL: `domains` FIELD — ROOT DOMAINS ONLY**
+> The `domains` field is used for email address matching (e.g., `user@cs.usc.edu` → root domain `usc.edu`). It MUST contain only the root domain, never a subdomain.
 >
 > - **Correct:** `usc.edu`, `itu.edu.tr`, `ox.ac.uk`
 > - **Incorrect:** `cs.usc.edu`, `ogr.itu.edu.tr`, `mail.ox.ac.uk`
 >
-> Pull Requests containing subdomains will automatically fail the CI/CD checks.
+> This restriction applies **only to `domains`**. The `web_pages` field may contain any valid URL, including subdomains.
+>
+> Pull Requests containing subdomains in `domains` will automatically fail the CI/CD checks.
 
 ### 3. Pull Request Process
 


### PR DESCRIPTION
## Summary

- Clarifies that the ROOT DOMAINS ONLY rule applies to the `domains` field only — `web_pages` may contain any valid URL including subdomains
- Adds `https://` preference and trailing slash requirement for `web_pages`
- Adds university name rules (native Latin characters for Latin-script languages, English/romanized for non-Latin scripts)
- Adds country field rule: ISO 3166-1 English short name
- Syncs `copilot-instructions.md` with the same rules to prevent AI reviewer misinterpretation