### PR TITLE
Load contribution rules dynamically from CONTRIBUTING.md in AI reviewer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,13 +63,8 @@ Troubleshooting: Test failures almost always mean you introduced a duplicate dom
 
 ### 3. Data Entry Validation Guidelines
 
-To further ensure your modifications are accepted seamlessly, always validate your intent against these domain rules:
+Before proposing any addition or modification, verify the university online if you have internet access — confirm the name, domain, and web page are correct and active.
 
-- **Internet Validation (If Applicable):** If you are equipped with internet access or web search capabilities, always search for the university online to validate the correctness of its name, domain, and primary web page before proposing an addition or modification. Ensure the domain actively resolves to the stated institution.
-- **Root Domains Only (`domains` field):** Universities often use subdomains for departments or student email scopes (e.g., `student@cs.usc.edu`). The `domains` array must only contain the root domain (e.g., `usc.edu`, not `cs.usc.edu`). This restriction applies **only to `domains`**, not to `web_pages`.
-- **No Protocols in Domains:** The `domains` array must contain bare domain names without any protocol prefix (e.g., `sabanciuniv.edu`, not `http://www.sabanciuniv.edu`).
-- **Web Pages Array:** The `web_pages` array must include the protocol and may point to any valid URL, including subdomains (e.g., `https://newsite.university.edu/`). Prefer `https://` over `http://`; only use `http://` if the site does not support HTTPS. URLs must end with a trailing slash.
-- **University Name:** For universities using a Latin-alphabet language (French, German, Spanish, Turkish, etc.), use the official name in the original language including native characters (e.g., `Boğaziçi University`, `Université Paris-Saclay`). For non-Latin scripts (Arabic, Chinese, Cyrillic, etc.), use the official English name or a standard romanized transliteration.
-- **Country Field:** Use the full English country name following ISO 3166-1 English short names (e.g., `"Turkey"`, not `"Türkiye"` or `"Deutschland"`).
+For all data entry rules (field formats, naming conventions, domain restrictions, `web_pages` requirements, etc.), refer to **[CONTRIBUTING.md](../CONTRIBUTING.md)** as the single source of truth.
 
 **When to Search:** Rely strictly on the paths and commands provided here. Only use grep, find, or repository searches if the validation test suite fails due to missing files, or if the Python environment indicates missing upstream dependencies.

--- a/.github/workflows/ai-pr-reviewer.py
+++ b/.github/workflows/ai-pr-reviewer.py
@@ -47,10 +47,38 @@ def post_comment(comment):
     print("✅ Comment successfully posted!")
 
 
+def get_contributing_guide():
+    try:
+        with open("CONTRIBUTING.md", "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        print("⚠️ CONTRIBUTING.md not found, falling back to built-in rules.")
+        return None
+
+
 def analyze_diff(diff_text):
     if "world_universities_and_domains.json" not in diff_text:
         print("⏭️ No changes detected in the university database. Skipping review.")
         return None
+
+    contributing_guide = get_contributing_guide()
+
+    if contributing_guide:
+        rules_section = f"""
+    The official contribution guidelines for this repository are:
+
+    ---
+    {contributing_guide}
+    ---
+    """
+    else:
+        rules_section = """
+    Evaluate against these rules:
+    1. **Existence**: Is it a real, recognized university?
+    2. **Schema**: Does it have `name`, `country`, `alpha_two_code`, `domains`, `web_pages`, `state-province`?
+    3. **ROOT DOMAINS ONLY (applies to `domains` field only)**: The `domains` array must contain only root domains — subdomains are forbidden (e.g., `usc.edu` is correct, `cs.usc.edu` is not). This rule does NOT apply to `web_pages`; `web_pages` may contain any valid URL including subdomains.
+    4. **Formatting**: Valid JSON format?
+    """
 
     prompt = f"""
     You are an expert maintainer for an open-source global university database.
@@ -59,13 +87,8 @@ def analyze_diff(diff_text):
     ```diff
     {diff_text}
     ```
-
-    Evaluate ONLY the newly added lines (starting with '+') against our STRICT rules:
-    1. **Existence**: Is it a real, recognized university?
-    2. **Schema**: Does it have `name`, `country`, `alpha_two_code`, `domains`, `web_pages`, `state-province`?
-    3. **ROOT DOMAINS ONLY**: Subdomains (like cs.usc.edu) are strictly forbidden.
-    4. **Formatting**: Valid JSON format?
-
+    {rules_section}
+    Evaluate ONLY the newly added lines (starting with '+').
     Format your output as a clear checklist. Conclude with either "✅ PASSED" or "❌ FLAGGED: [Reason]".
     """
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 __pycache__/
 *DS_Store
+node_modules/


### PR DESCRIPTION
## Summary

- `ai-pr-reviewer.py` now reads rules from `CONTRIBUTING.md` at runtime instead of hardcoding them in the prompt — rules only need to be maintained in one place
- `copilot-instructions.md` validation guidelines section replaced with a reference to `CONTRIBUTING.md` to eliminate duplication

## Why

The previous hardcoded prompt lacked the `domains` vs `web_pages` distinction, causing the AI reviewer to incorrectly flag valid `web_pages` subdomain URLs. With dynamic loading, any future update to `CONTRIBUTING.md` is automatically picked up by the reviewer.