### PR TITLE
Add Charité – Universitätsmedizin Berlin (charite.de)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -27682,7 +27682,7 @@
     "web_pages": ["https://www.charite.de/"],
     "name": "Charité – Universitätsmedizin Berlin",
     "alpha_two_code": "DE",
-    "state-province": null,
+    "state-province": "Berlin",
     "domains": ["charite.de"],
     "country": "Germany"
   },

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -27679,6 +27679,14 @@
     "country": "Germany"
   },
   {
+    "web_pages": ["https://www.charite.de/"],
+    "name": "Charité – Universitätsmedizin Berlin",
+    "alpha_two_code": "DE",
+    "state-province": null,
+    "domains": ["charite.de"],
+    "country": "Germany"
+  },
+  {
     "web_pages": ["http://code.berlin/"],
     "name": "CODE University of Applied Sciences Berlin",
     "alpha_two_code": "DE",


### PR DESCRIPTION
## Description

Adds **Charité – Universitätsmedizin Berlin** (`charite.de`) — one of Europe's largest university hospitals and the joint medical faculty of Freie Universität Berlin and Humboldt-Universität zu Berlin (both already in the list as `fu-berlin.de` / `hu-berlin.de`). It is a degree-granting institution (medicine, dental medicine, health sciences) with its own primary domain used for staff, researcher, and student email addresses.

Entry placed in the alphabetical run of the Germany block (between `cbs.de` and `code.berlin`).

## Data Completeness Checklist

- [x] **Full Schema:** Does every entry include `name`, `country`, `domains`, `web_pages`, and `alpha_two_code`?
- [x] **State/Province:** If applicable, is the `state-province` field filled? — set to `"Berlin"`
- [x] **Data Accuracy:** Have you verified the official site and domain? — https://www.charite.de/
- [x] **No Duplicates:** Have you searched the file to ensure this entry doesn't already exist? — no entry matches "charite" (name or domain)
- [x] **Root Domain Only:** Does the `domains` array contain ONLY root domains? — `charite.de`
- [x] **Root URL Only:** Does every `web_pages` entry point to a root URL? — `https://www.charite.de/`

## Technical Checks

- [x] JSON is valid and correctly formatted.
- [x] No trailing commas or syntax errors.

All 13 tests in `tests/` pass locally.