### PR TITLE
fix: prioritize official English name in university name rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,16 @@ All university data is stored in `world_universities_and_domains.json`. When add
 
 ### University Name Rules (`name` field)
 
-**Latin-alphabet languages** (French, German, Spanish, Turkish, Portuguese, etc.):
+**Priority rule — official English name:**
+If the university has an official English name (used on its own website or in official communications), always prefer it regardless of the language of instruction or country.
+
+```text
+"Ho Chi Minh City University of Technology"  ✓  (official English name exists)
+"King Abdulaziz University"                  ✓  (official English name exists)
+"Peking University"                          ✓  (official English name exists)
+```
+
+**Latin-alphabet languages — no official English name** (French, German, Spanish, Turkish, Portuguese, etc.):
 Use the official name in the original language, including native characters.
 
 ```text
@@ -29,12 +38,10 @@ Use the official name in the original language, including native characters.
 "Technische Universität Wien" ✓  (not "Vienna University of Technology")
 ```
 
-**Non-Latin-script languages** (Arabic, Chinese, Japanese, Korean, Cyrillic, etc.):
-Use the official English name. If no official English name exists, use a standard romanized transliteration.
+**Non-Latin-script languages — no official English name** (Arabic, Chinese, Japanese, Korean, Cyrillic, etc.):
+Use a standard romanized transliteration.
 
 ```text
-"Peking University"           ✓  (not "北京大学")
-"King Abdulaziz University"   ✓  (not "جامعة الملك عبدالعزيز")
 "Moscow State University"     ✓  (not "Московский государственный университет")
 ```
 


### PR DESCRIPTION
## Summary

- Adds a new top-level **priority rule**: if a university has an official English name, always prefer it regardless of script or country
- Scopes the Latin-alphabet and non-Latin-script rules to only apply when no official English name exists
- Fixes incorrect AIOps behavior that was flagging valid English names for Latin-alphabet countries (e.g. Vietnamese universities)

## Motivation

All Vietnamese universities in the dataset consistently use English names, but the previous rule classified Vietnamese as a "Latin-alphabet language" and instructed reviewers to use the native name. This caused the automated AIOps reviewer to wrongly flag correct English names in PRs.

## Test plan

- [ ] Verify AIOps no longer flags English names for universities in Latin-alphabet countries that have official English names
- [ ] Confirm existing entries like `"Boğaziçi University"` (no official English name) are still valid under the updated rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)