### PR TITLE
Fix ruff lint errors in ai-pr-review.py

### DIFF
--- a/.github/workflows/ai-pr-review.py
+++ b/.github/workflows/ai-pr-review.py
@@ -100,8 +100,10 @@ def analyze_diff(diff_text):
             )
             print("✅ Gemini successfully generated a response.")
             return f"🤖 **AIOps Comprehensive PR Review**\n\n{response.text}\n\n---\n*Note: Automated review based on repository contribution guidelines.*"
-        except Exception as e:
-            print(f"⚠️ Gemini API Error (attempt {attempt + 1}/3): {str(e)}")
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 - retry loop must survive any SDK/network failure
+            print(f"⚠️ Gemini API Error (attempt {attempt + 1}/3): {e!s}")
             if attempt < 2:
                 time.sleep(10)
 

--- a/.github/workflows/ai-pr-review.py
+++ b/.github/workflows/ai-pr-review.py
@@ -100,9 +100,8 @@ def analyze_diff(diff_text):
             )
             print("✅ Gemini successfully generated a response.")
             return f"🤖 **AIOps Comprehensive PR Review**\n\n{response.text}\n\n---\n*Note: Automated review based on repository contribution guidelines.*"
-        except (
-            Exception
-        ) as e:  # noqa: BLE001 - retry loop must survive any SDK/network failure
+        # Retry loop must survive any SDK/network failure from the Gemini call.
+        except Exception as e:  # noqa: BLE001
             print(f"⚠️ Gemini API Error (attempt {attempt + 1}/3): {e!s}")
             if attempt < 2:
                 time.sleep(10)


### PR DESCRIPTION
## Summary
- The `lint` CI job was failing on `ai-pr-review.py` with two ruff errors: `BLE001` (blind `except Exception`) and `RUF010` (use explicit conversion flag instead of `str(e)`).
- Replaced `{str(e)}` with `{e!s}` in the f-string.
- Added a justified `noqa: BLE001` since the retry loop around the Gemini API call is intended to survive any SDK/network failure.

Ref: https://github.com/Hipo/university-domains-list/actions/runs/30169095603/job/89706969950

## Test plan
- [x] `ruff check .github/workflows/ai-pr-review.py` passes locally