### PR TITLE
Clarify state-province field rules in contribution guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ This PR proposes changes/additions to the university database.
 ## Data Completeness Checklist
 
 - [ ] **Full Schema:** Does every entry include `name`, `country`, `domains`, `web_pages`, and `alpha_two_code`?
-- [ ] **State/Province:** If applicable, is the `state-province` field filled? (If not available, ensure the field exists as `null`).
+- [ ] **State/Province:** Is `state-province` filled for single-campus universities in countries with state/province divisions? `null` is only for multi-campus universities or countries without such divisions.
 - [ ] **Data Accuracy:** Have you verified the official site and domain?
 - [ ] **No Duplicates:** Have you searched the file to ensure this entry doesn't already exist?
 - [ ] **Root Domain Only:** Does the `domains` array contain ONLY root domains? (e.g., `usc.edu` is correct, `cs.usc.edu` or `mail.usc.edu` is WRONG).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ All university data is stored in `world_universities_and_domains.json`. When add
   - `alpha_two_code`: Standard ISO 3166-1 alpha-2 code (e.g., `"US"`, `"TR"`).
   - `domains`: An array of the university's primary registered domains — no department or service prefixes (see critical note below).
   - `web_pages`: An array of URL strings (even if there is only one). Must be the **root URL** of the university's website — no path beyond `/` (e.g., `https://www.university.edu/`, not `https://www.university.edu/admissions/`). Subdomains are allowed (e.g., `https://newsite.university.edu/`). Must begin with `https://` (preferred). Only use `http://` if the university's site does not support HTTPS. Must end with a trailing slash.
-  - `state-province`: State or province name in English. Use `null` if not applicable.
+  - `state-province`: State or province name in English (see rules below).
 - **Accuracy:** Ensure the domains and web pages are currently active.
 - **No Duplicates:** Check if the university already exists under a different name or variation.
 
@@ -48,6 +48,36 @@ Use a standard romanized transliteration.
 > **Note on consistency:** If you are fixing an existing entry that uses ASCII instead of the correct native characters (e.g., `"Ataturk University"` instead of `"Atatürk University"`), correcting it is welcome — just note the fix in your PR description.
 
 **Note on character encoding:** Native characters (ü, ö, ğ, é, etc.) are valid UTF-8 and work fine in JSON. However, applications consuming this data that do exact string matching may miss results if they search with ASCII equivalents (e.g., searching `"Ataturk"` won't match `"Atatürk"`). API consumers should apply Unicode normalization on their side when doing name lookups.
+
+### State/Province Rules (`state-province` field)
+
+`null` is not a default — it's only correct in two specific cases. In every other case the field must be filled in.
+
+**Must be filled in** when **both** are true:
+
+- The university has a single campus (one physical location).
+- The country has a meaningful state/province-level administrative division, and you know which one the campus is in.
+
+**`null` is acceptable** when **either** is true:
+
+- The university has multiple campuses spread across different states/provinces (no single value could represent it correctly).
+- The country has no state/province-level administrative structure (e.g. small or single-jurisdiction countries).
+
+**Note on terminology:** `state-province` covers whatever a country calls its top-level administrative division — prefecture (Japan), region (Italy, France), canton (Switzerland), oblast (Russia), governorate (Egypt), emirate (UAE), etc. Don't leave the field `null` just because your country doesn't literally call it a "state" or "province."
+
+**Note on format:** Use the full official English name of the subdivision, not an abbreviation or code (e.g. `"California"`, not `"CA"`).
+
+**Never use an empty string.** The field must be either a real value or the JSON literal `null` — `""` is not a valid state.
+
+```text
+"state-province": "California"   ✓  (single-campus US university)
+"state-province": "Osaka"        ✓  (Japan — prefecture counts as state-province)
+"state-province": null           ✓  (campuses in multiple states/provinces)
+"state-province": null           ✓  (country has no state/province divisions)
+"state-province": ""             ✗  (empty string is never valid — use null instead)
+"state-province": "CA"           ✗  (abbreviation — use the full name "California")
+"state-province": null           ✗  (single campus, country has provinces, info available — must be filled)
+```
 
 ### 2. Example Entry
 


### PR DESCRIPTION
## Summary
- Specifies exactly when `state-province` must be filled vs. when `null` is acceptable: required for single-campus universities in countries with a meaningful state/province-level division, `null` only for multi-campus universities or countries without such divisions.
- Clarifies that `state-province` covers equivalent terms in other countries (prefecture, region, canton, oblast, governorate, emirate, etc.), not just literal "state"/"province".
- Requires full official names instead of abbreviations/codes, and forbids empty strings (must be a real value or JSON `null`).
- Updates the PR template checklist item to match.

## Test plan
- [x] Markdown renders correctly, no lint warnings
- [x] Pre-commit hooks pass