### PR TITLE
fix unniv on Toulouse

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -27191,35 +27191,27 @@
     "country": "France"
   },
   {
-    "web_pages": ["http://www.univ-tlse1.fr/"],
-    "name": "Université des Sciences Sociales (Toulouse I)",
+    "web_pages": ["https://www.ut-capitole.fr/"],
+    "name": "Université Toulouse Capitole",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-tlse1.fr"],
     "country": "France"
   },
   {
-    "web_pages": ["http://www.univ-tlse2.fr/"],
-    "name": "Université de Toulouse-le-Mirail (Toulouse II)",
+    "web_pages": ["https://www.univ-tlse2.fr/"],
+    "name": "Unniversité Toulouse Jean Jaurès",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-tlse2.fr"],
     "country": "France"
   },
   {
-    "web_pages": ["http://www.univ-tlse3.fr/"],
-    "name": "Université de Toulouse-le-Mirail (Toulouse III)",
-    "alpha_two_code": "FR",
-    "state-province": null,
-    "domains": ["univ-tlse3.fr"],
-    "country": "France"
-  },
-  {
-    "web_pages": ["http://www.univ-toulouse.fr/"],
+    "web_pages": ["https://www.univ-tlse3.fr/"],
     "name": "Université de Toulouse",
     "alpha_two_code": "FR",
     "state-province": null,
-    "domains": ["univ-toulouse.fr"],
+    "domains": ["univ-tlse3.fr"],
     "country": "France"
   },
   {

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -27200,7 +27200,7 @@
   },
   {
     "web_pages": ["https://www.univ-tlse2.fr/"],
-    "name": "Unniversité Toulouse Jean Jaurès",
+    "name": "Université Toulouse Jean Jaurès",
     "alpha_two_code": "FR",
     "state-province": null,
     "domains": ["univ-tlse2.fr"],


### PR DESCRIPTION
## Description

This PR proposes changes to the university database.

## Data Completeness Checklist

- [ X] **Full Schema:** Does every entry include `name`, `country`, `domains`, `web_pages`, and `alpha_two_code`?
- [ ]X **State/Province:** Is `state-province` filled for single-campus universities in countries with state/province divisions? `null` is only for multi-campus universities or countries without such divisions.
- [ X] **Data Accuracy:** Have you verified the official site and domain?
- [ X] **No Duplicates:** Have you searched the file to ensure this entry doesn't already exist?
- [ X] **Root Domain Only:** Does the `domains` array contain ONLY root domains? (e.g., `usc.edu` is correct, `cs.usc.edu` or `mail.usc.edu` is WRONG).
- [X ] **Root URL Only:** Does every `web_pages` entry point to a root URL? (e.g., `https://www.university.edu/` is correct, `https://www.university.edu/admissions/` is WRONG).

## Technical Checks

- [ ] JSON is valid and correctly formatted.
- [ ] No trailing commas or syntax errors.

**Note:** Please ensure all fields are present for every entry to maintain data integrity.

Something to note, even if `univ-tlse3.fr` is the official domain for the website, the university start to go for `utoulouse.fr` as the domain, which can lead to error, e.g. student email are `name.surname@utoulouse.fr`