### PR TITLE
Add Luleå University of Technology (ltu.se)

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -82106,5 +82106,13 @@
     "state-province": "Khanh Hoa",
     "domains": ["ntc.edu.vn"],
     "country": "Vietnam"
+  },
+  {
+    "name": "Luleå University of Technology",
+    "domains": ["ltu.se"],
+    "web_pages": ["https://www.ltu.se/"],
+    "country": "Sweden",
+    "alpha_two_code": "SE",
+    "state-province": null
   }
 ]

--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -82113,6 +82113,6 @@
     "web_pages": ["https://www.ltu.se/"],
     "country": "Sweden",
     "alpha_two_code": "SE",
-    "state-province": null
+    "state-province": "Norrbotten"
   }
 ]


### PR DESCRIPTION
Missing entry for Luleå University of Technology, Sweden.

